### PR TITLE
Remove byref flags in non-virtual gamedata

### DIFF
--- a/addons/sourcemod/gamedata/scp_sf.txt
+++ b/addons/sourcemod/gamedata/scp_sf.txt
@@ -165,7 +165,6 @@
 					"inputdata"
 					{
 						"type"	"objectptr"
-						"flags"	"byref"
 					}
 				}
 			}			
@@ -307,7 +306,6 @@
 					"info"
 					{
 						"type"	"objectptr"
-						"flags"	"byref"
 					}
 					"bEmpty"
 					{


### PR DESCRIPTION
DHooks update in SM 1.11 doesn't like byref flag in non-virtual gamedata, remove it.