### PR TITLE
Few changes to Flash Grenade

### DIFF
--- a/addons/sourcemod/scripting/scp_sf/items.sp
+++ b/addons/sourcemod/scripting/scp_sf/items.sp
@@ -1830,7 +1830,8 @@ public Action Items_FlashTimer(Handle timer, int ref)
 			AttachParticle(explosion, "drg_cow_explosioncore_normal_blue", false, 5.0);
 			EmitGameSoundToAll("Weapon_Detonator.Detonate", entity);	
 			
-			int light = TF2_CreateLightEntity(512.0, { 255, 255, 255, 255 }, 5, 0.2);
+			// create a short light effect, clientside duration can increase slightly depending on ping
+			int light = TF2_CreateLightEntity(1024.0, { 255, 255, 255, 255 }, 5, 0.1);
 			if (light > MaxClients)
 				TeleportEntity(light, pos1, view_as<float>({ 90.0, 0.0, 0.0 }), NULL_VECTOR);
 			

--- a/addons/sourcemod/scripting/scp_sf/stocks.sp
+++ b/addons/sourcemod/scripting/scp_sf/stocks.sp
@@ -401,7 +401,7 @@ public Action Timer_RemoveEntity(Handle timer, any entid)
 	if(IsValidEdict(entity) && entity>MaxClients)
 	{
 		TeleportEntity(entity, OFF_THE_MAP, NULL_VECTOR, NULL_VECTOR); // send it away first in case it feels like dying dramatically
-		AcceptEntityInput(entity, "Kill");
+		RemoveEntity(entity);
 	}
 	return Plugin_Continue;
 }
@@ -1731,27 +1731,8 @@ stock int TF2_CreateLightEntity(float radius, int color[4], int brightness, floa
 			SetEdictFlags(entity, flags);
 		}
 		
-		CreateTimer(lifetime, Timer_DestroyLight, EntIndexToEntRef(entity), TIMER_FLAG_NO_MAPCHANGE);	
+		CreateTimer(lifetime, Timer_RemoveEntity, EntIndexToEntRef(entity), TIMER_FLAG_NO_MAPCHANGE);
 	}
 	
 	return entity;
-}
-
-public Action Timer_DestroyLight(Handle timer, int ref)
-{
-	int entity = EntRefToEntIndex(ref);
-	if (entity > MaxClients)
-	{
-		AcceptEntityInput(entity, "TurnOff");
-		RequestFrame(Frame_KillLight, ref);
-	}
-	
-	return Plugin_Continue;
-}
-
-void Frame_KillLight(int ref)
-{
-	int entity = EntRefToEntIndex(ref);
-	if (entity > MaxClients)
-		AcceptEntityInput(entity, "Kill");
 }

--- a/addons/sourcemod/scripting/scp_sf/stocks.sp
+++ b/addons/sourcemod/scripting/scp_sf/stocks.sp
@@ -1701,9 +1701,9 @@ stock int TF2_CreateLightEntity(float radius, int color[4], int brightness, floa
 	int entity = CreateEntityByName("light_dynamic");
 	if (entity != -1)
 	{			
-		char lightcolor[32];
-		Format(lightcolor, sizeof(lightcolor), "%i %i %i", color[0], color[1], color[2]);
-		DispatchKeyValue(entity, "rendercolor", lightcolor);
+		char lightColor[32];
+		Format(lightColor, sizeof(lightColor), "%d %d %d", color[0], color[1], color[2]);
+		DispatchKeyValue(entity, "rendercolor", lightColor);
 		
 		SetVariantFloat(radius);
 		AcceptEntityInput(entity, "spotlight_radius");


### PR DESCRIPTION
Changes to Flash Grenade:
- No longer flashes people through walls. It's the whole point of this PR, as it kinda... makes sense. Doesn't really feel right for it to affect people who are taking cover. The rest of the PR is just added fluff.
- Added a short light effect when it explodes, for enemies taking cover nearby or teammates in general to see.
- Removed the default explosion sound from it. Looks like it was trying to play a different sound, but that didn't work half the time (and was always drowned out by the default explosion sound anyway). That's patched up now.
	- Also seems like frag grenades suffer from this same issue, but should be looked into in a different PR.

[Outdated preview](https://cdn.discordapp.com/attachments/332809334339665930/1002917306722177124/2022-07-30_09-34-40.mp4) - showcases flashes not going through walls

[Updated preview](https://cdn.discordapp.com/attachments/332809334339665930/1003216246814285835/2022-07-31_05-19-06.mp4) - showcases up-to-date light effects

(they're downloadable videos)