### PR TITLE
Don't play the "low health" reaction if a player is crouching

### DIFF
--- a/addons/sourcemod/scripting/scp_sf/stocks.sp
+++ b/addons/sourcemod/scripting/scp_sf/stocks.sp
@@ -1162,7 +1162,7 @@ public Action Timer_Stun(Handle timer, DataPack pack)
 public Action Timer_MyBlood(Handle timer, int userid)
 {
 	int client = GetClientOfUserId(userid);
-	if(client && IsClientInGame(client) && !IsSpec(client) && GetClientHealth(client)<26)
+	if(client && IsClientInGame(client) && !IsSpec(client) && GetClientHealth(client)<26 && !(GetEntityFlags(client) & FL_DUCKING))
 		Config_DoReaction(client, "lowhealth");
 
 	return Plugin_Continue;


### PR DESCRIPTION
The "friendly death" reaction already considers this, but in that case the crouch check is made before creating a shorter timer, while in this case it's checked after the timer done. (Because 3 seconds is a relatively long time!)

This suggestion is being done because it feels annoying to sometimes be hit by a doglizard SCP at random, then having your position be given away by the reaction seconds later, as the most common example. The friendly death reaction excuses this with "crouching players are likely trying to be sneaky," the same applies here.