### PR TITLE
Fix item duplication exploit

### DIFF
--- a/addons/sourcemod/scripting/scp_sf/classes.sp
+++ b/addons/sourcemod/scripting/scp_sf/classes.sp
@@ -1552,9 +1552,14 @@ public bool Classes_DefaultVoice(int client)
 	GetCmdArgString(buffer, sizeof(buffer));
 	if(StrContains(buffer, "0 0"))
 		return false;
-
-	Client[client].UseBuffer = true;
-	return AttemptGrabItem(client);
+	
+	if (!Client[client].UseBuffer)
+	{
+		Client[client].UseBuffer = true;
+		return AttemptGrabItem(client);
+	}
+	
+	return true;
 }
 
 public bool Classes_GhostVoice(int client)


### PR DESCRIPTION
Found by [Sandshark](https://steamcommunity.com/id/hellrauser/)!

Without going into much detail before merging, it's possible to duplicate any item that you can carry more than one of.

I don't expect this fix to break anything else, but as simple as it is, I could be wrong. As far as I can test, everything's working fine.