### PR TITLE
Disallow SCP-939-89/-53 from targeting other players with voice commands

### DIFF
--- a/addons/sourcemod/gamedata/scp_sf.txt
+++ b/addons/sourcemod/gamedata/scp_sf.txt
@@ -107,6 +107,16 @@
 				"linux"		"@_ZN14CWeaponMedigun19AllowedToHealTargetEP11CBaseEntity"
 				"windows"	"\x55\x8B\xEC\x53\x8B\xD9\x56\x57\x8B\xB3\xE8\x01\x00\x00\x83\xFE\xFF\x0F\x84\x64\x01"
 			}
+			"AI_CriteriaSet::FindCriterionIndex"
+			{
+				"linux"		"@_ZNK14AI_CriteriaSet18FindCriterionIndexEPKc"
+				"windows"	"\x55\x8B\xEC\x83\xEC\x48\x56\xFF\x75\x08"
+			}
+			"AI_CriteriaSet::RemoveCriteria"
+			{
+				"linux"		"@_ZN14AI_CriteriaSet14RemoveCriteriaEPKc"
+				"windows"	"\x55\x8B\xEC\x83\xEC\x48\x56\x57\xFF\x75\x08"
+			}
 			// FIXME: remove this when SM 1.11 is stable (TR_EnumerateEntitiesSphere can be used instead)
 			// thanks to nosoop for this sig
 			"CGlobalEntityList::FindEntityInSphere()"
@@ -374,6 +384,20 @@
 					}
 				}
 			}
+			"CBaseEntity::ModifyOrAppendCriteria"
+			{
+				"offset"	"CBaseEntity::ModifyOrAppendCriteria"
+				"hooktype"	"entity"
+				"return"	"void"
+				"this"		"entity"
+				"arguments"
+				{
+					"criteriaSet"
+					{
+						"type"	"int"
+					}
+				}
+			}
 		}
 		"Offsets"
 		{
@@ -426,6 +450,11 @@
 			{
 				"linux"		"207"
 				"windows"	"206"
+			}
+			"CBaseEntity::ModifyOrAppendCriteria"
+			{
+				"linux"		"122"
+				"windows"	"121"
 			}
 		}
 		"Addresses"

--- a/addons/sourcemod/scripting/scp_sf/classes.sp
+++ b/addons/sourcemod/scripting/scp_sf/classes.sp
@@ -1477,7 +1477,7 @@ public bool Classes_PickupScp(int client, int entity)
 
 public Action Classes_SoundHuman(int client, char sample[PLATFORM_MAX_PATH], int &channel, float &volume, int &level, int &pitch, int &flags, char soundEntry[PLATFORM_MAX_PATH], int &seed)
 {
-	if(!StrContains(sample, "vo", false))
+	if(!StrContains(sample, "vo/", false))
 	{
 		if(IsSpec(client))
 			return Plugin_Handled;
@@ -1485,12 +1485,11 @@ public Action Classes_SoundHuman(int client, char sample[PLATFORM_MAX_PATH], int
 		level = RoundFloat(level / 1.2);
 		return Plugin_Changed;
 	}
-	else if(StrContains(sample, "footsteps", false) != -1)
+	else if(StrContains(sample, "footsteps/", false) != -1)
 	{
 		if(Client[client].Sprinting)
 		{
 			level += 20;
-			volume *= 2.0;
 			return Plugin_Changed;
 		}
 
@@ -1506,15 +1505,14 @@ public Action Classes_SoundHuman(int client, char sample[PLATFORM_MAX_PATH], int
 
 public Action Classes_SoundScp(int client, char sample[PLATFORM_MAX_PATH], int &channel, float &volume, int &level, int &pitch, int &flags, char soundEntry[PLATFORM_MAX_PATH], int &seed)
 {
-	if(!StrContains(sample, "vo", false))
+	if(!StrContains(sample, "vo/", false))
 	{
 		if(!TF2_IsPlayerInCondition(client, TFCond_Disguised))
 			return Plugin_Handled;
 	}
-	else if(StrContains(sample, "footsteps", false) != -1)
+	else if(StrContains(sample, "footsteps/", false) != -1)
 	{
 		level += 20;
-		volume *= 2.0;
 		return Plugin_Changed;
 	}
 	return Plugin_Continue;

--- a/addons/sourcemod/scripting/scp_sf/sdkcalls.sp
+++ b/addons/sourcemod/scripting/scp_sf/sdkcalls.sp
@@ -7,6 +7,8 @@ Handle SDKInitWeapon;
 static Handle SDKInitPickup;
 static Handle SDKSetSpeed;
 static Handle SDKFindEntityInSphere;
+static Handle SDKFindCriterionIndex;
+static Handle SDKRemoveCriteria;
 
 void SDKCall_Setup(GameData gamedata)
 {
@@ -81,6 +83,21 @@ void SDKCall_Setup(GameData gamedata)
 	PrepSDKCall_AddParameter(SDKType_Vector, SDKPass_ByRef);
 	PrepSDKCall_AddParameter(SDKType_Float, SDKPass_Plain);
 	SDKFindEntityInSphere = EndPrepSDKCall();
+	
+	StartPrepSDKCall(SDKCall_Raw);
+	PrepSDKCall_SetFromConf(gamedata, SDKConf_Signature, "AI_CriteriaSet::FindCriterionIndex");
+	PrepSDKCall_AddParameter(SDKType_String, SDKPass_Pointer);
+	PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_Plain);
+	SDKFindCriterionIndex = EndPrepSDKCall();
+	if (!SDKFindCriterionIndex)
+		LogMessage("Failed to create SDKCall: AI_CriteriaSet::FindCriterionIndex");
+	
+	StartPrepSDKCall(SDKCall_Raw);
+	PrepSDKCall_SetFromConf(gamedata, SDKConf_Signature, "AI_CriteriaSet::RemoveCriteria");
+	PrepSDKCall_AddParameter(SDKType_String, SDKPass_Pointer);
+	SDKRemoveCriteria = EndPrepSDKCall();
+	if (!SDKRemoveCriteria)
+		LogMessage("Failed to create SDKCall: AI_CriteriaSet::RemoveCriteria");
 }
 
 void SDKCall_EquipWearable(int client, int entity)
@@ -151,6 +168,20 @@ void ChangeClientTeamEx(int client, any newTeam)
 		}
 	}
 	SetEntProp(client, Prop_Send, "m_iTeamNum", newTeam);
+}
+
+int SDKCall_FindCriterionIndex(int criteriaSet, const char[] criteria)
+{
+	if (SDKFindCriterionIndex)
+		return SDKCall(SDKFindCriterionIndex, criteriaSet, criteria);
+	else
+		return -1;
+}
+
+void SDKCall_RemoveCriteria(int criteriaSet, const char[] criteria)
+{
+	if (SDKRemoveCriteria)
+		SDKCall(SDKRemoveCriteria, criteriaSet, criteria);
 }
 
 // FIXME: remove this when SM 1.11 is stable (TR_EnumerateEntitiesSphere can be used instead)


### PR DESCRIPTION
Stops people from using the spy voice command spam strat to find people they can't see, they'll be treated as if they're aiming towards no one. Almost all of this comes from Mikusch's PropHunt, ty.

Misc. changes included in this PR:
- Removed the 2x volume on footsteps under certain conditions, which doesn't seem to work and spews a few messages in the server console.
- Soundhooks now check for `vo/` and `footsteps/` instead of `vo` and `footsteps` respectively. Just in case!

edited the title to be a bit more clear