### PR TITLE
Few changes to Frag Grenade

### DIFF
--- a/addons/sourcemod/gamedata/scp_sf.txt
+++ b/addons/sourcemod/gamedata/scp_sf.txt
@@ -117,17 +117,6 @@
 				"linux"		"@_ZN14AI_CriteriaSet14RemoveCriteriaEPKc"
 				"windows"	"\x55\x8B\xEC\x83\xEC\x48\x56\x57\xFF\x75\x08"
 			}
-			// FIXME: remove this when SM 1.11 is stable (TR_EnumerateEntitiesSphere can be used instead)
-			// thanks to nosoop for this sig
-			"CGlobalEntityList::FindEntityInSphere()"
-			{
-				// xref "NULL entity in global entity list!\n"
-				// process of elimination -- three arguments that branch to a mov+10004h
-				// two arguments is FindEntityByModel
-				"library"	"server"
-				"linux"		"@_ZN17CGlobalEntityList18FindEntityInSphereEP11CBaseEntityRK6Vectorf"
-				"windows"	"\x55\x8B\xEC\x83\xEC\x0C\x53\x56\x57\x8B\xF9\x8B\x4D\x08"
-			}
 		}
 		"Functions"
 		{

--- a/addons/sourcemod/scripting/scp_sf/items.sp
+++ b/addons/sourcemod/scripting/scp_sf/items.sp
@@ -1731,37 +1731,25 @@ public Action Items_FragTimer(Handle timer, int ref)
 		GetEntPropVector(entity, Prop_Send, "m_vecOrigin", pos);
 
 		int client = GetEntPropEnt(entity, Prop_Send, "m_hOwnerEntity");
-		int explosion = CreateEntityByName("env_explosion");
-		if(IsValidEntity(explosion))
+		int flags = (SF_ENVEXPLOSION_REPEATABLE|SF_ENVEXPLOSION_NODECAL|SF_ENVEXPLOSION_NOSOUND|SF_ENVEXPLOSION_RND_ORIENT|SF_ENVEXPLOSION_NOFIREBALLSMOKE|SF_ENVEXPLOSION_NOPARTICLES);
+		int explosion = CreateExplosion(client, 500, 350, pos, flags, "taunt_soldier", false);
+		
+		if (IsValidEntity(explosion))
 		{
-			DispatchKeyValueVector(explosion, "origin", pos);
-			DispatchKeyValue(explosion, "iMagnitude", "500");
-			DispatchKeyValue(explosion, "iRadiusOverride", "350");
-			// don't want particles or sound, we create them seperately
-			DispatchKeyValue(explosion, "spawnflags", "978");
-			
-			SetEntPropEnt(explosion, Prop_Data, "m_hOwnerEntity", client);
-			// pass the original class of the thrower
-			SetEntProp(explosion, Prop_Data, "m_iHammerID", GetEntProp(entity, Prop_Data, "m_iHammerID"));						
-			
-			DispatchSpawn(explosion);	
-			
-			// this will show the kill icon as a grenade
-			SetVariantString("classname taunt_soldier"); 
-			AcceptEntityInput(explosion, "AddOutput");
-			
 			AttachParticle(explosion, "asplode_hoodoo", false, 5.0);
-			EmitGameSoundToAll("Weapon_Airstrike.Explosion", entity);
+			EmitGameSoundToAll("Weapon_Airstrike.Explosion", explosion);
+			
+			// pass the original class of the thrower
+			SetEntProp(explosion, Prop_Data, "m_iHammerID", GetEntProp(entity, Prop_Data, "m_iHammerID"));	
 			
 			AcceptEntityInput(explosion, "Explode");
+			TR_EnumerateEntitiesSphere(pos, 350.0, PARTITION_SOLID_EDICTS, Items_FragTrace);
 			CreateTimer(0.1, Timer_RemoveEntity, EntIndexToEntRef(explosion), TIMER_FLAG_NO_MAPCHANGE);
 		}
-
+		
+		RemoveEntity(entity);
 		// find any doors nearby and try destroy or force them open
 		//CopyVector(pos, FragPos); // temporary for trace, used for pushing items away
-		TR_EnumerateEntitiesSphere(pos, 350.0, PARTITION_SOLID_EDICTS, Items_FragTrace);
-		
-		AcceptEntityInput(entity, "Kill");
 	}
 	return Plugin_Continue;
 }
@@ -1826,27 +1814,22 @@ public Action Items_FlashTimer(Handle timer, int ref)
 	{
 		static float pos1[3];
 		GetEntPropVector(entity, Prop_Send, "m_vecOrigin", pos1);
-
-		int explosion = CreateEntityByName("env_explosion");
-		if(IsValidEntity(explosion))
+		
+		int flags = (SF_ENVEXPLOSION_NODAMAGE|SF_ENVEXPLOSION_REPEATABLE|SF_ENVEXPLOSION_NODECAL|SF_ENVEXPLOSION_NOSOUND|SF_ENVEXPLOSION_RND_ORIENT|SF_ENVEXPLOSION_NOFIREBALLSMOKE|SF_ENVEXPLOSION_NOPARTICLES);
+		int explosion = CreateExplosion(_, _, _, pos1, flags, _, false);
+		
+		if (IsValidEntity(explosion))
 		{
-			DispatchKeyValueVector(explosion, "origin", pos1);
-			DispatchKeyValue(explosion, "iMagnitude", "0");
-			// don't want particles and sound, we create them seperately
-			DispatchKeyValue(explosion, "spawnflags", "978");
-			
-			SetEntPropEnt(explosion, Prop_Data, "m_hOwnerEntity", GetEntPropEnt(entity, Prop_Send, "m_hOwnerEntity"));
-			// pass the original class of the thrower
-			SetEntProp(explosion, Prop_Data, "m_iHammerID", GetEntProp(entity, Prop_Data, "m_iHammerID"));
-			
-			DispatchSpawn(explosion);
-			AttachParticle(explosion, "drg_cow_explosioncore_normal_blue", false, 5.0);
-			EmitGameSoundToAll("Weapon_Detonator.Detonate", entity);	
+			AttachParticle(explosion, "drg_cow_explosioncore_normal_blue", false, 1.0);
+			EmitGameSoundToAll("Weapon_Detonator.Detonate", explosion);
 			
 			// create a short light effect, clientside duration can increase slightly depending on ping
 			int light = TF2_CreateLightEntity(1024.0, { 255, 255, 255, 255 }, 5, 0.1);
 			if (light > MaxClients)
 				TeleportEntity(light, pos1, view_as<float>({ 90.0, 0.0, 0.0 }), NULL_VECTOR);
+			
+			// pass the original class of the thrower
+			SetEntProp(explosion, Prop_Data, "m_iHammerID", GetEntProp(entity, Prop_Data, "m_iHammerID"));	
 			
 			AcceptEntityInput(explosion, "Explode");
 			CreateTimer(0.1, Timer_RemoveEntity, EntIndexToEntRef(explosion), TIMER_FLAG_NO_MAPCHANGE);
@@ -1872,7 +1855,7 @@ public Action Items_FlashTimer(Handle timer, int ref)
 			}
 		}
 
-		AcceptEntityInput(entity, "Kill");
+		RemoveEntity(entity);
 	}
 	return Plugin_Continue;
 }

--- a/addons/sourcemod/scripting/scp_sf/items.sp
+++ b/addons/sourcemod/scripting/scp_sf/items.sp
@@ -1689,6 +1689,7 @@ public bool Items_FragButton(int client, int weapon, int &buttons, int &holding)
 //float FragPos[3];
 bool Items_FragTrace(int entity)
 {
+	// things like static props do go through, ignore them
 	if (!IsValidEntity(entity))
 		return true;
 	
@@ -1757,7 +1758,7 @@ public Action Items_FragTimer(Handle timer, int ref)
 		}
 
 		// find any doors nearby and try destroy or force them open
-		//CopyVector(pos, FragPos); // temporary for trace
+		//CopyVector(pos, FragPos); // temporary for trace, used for pushing items away
 		TR_EnumerateEntitiesSphere(pos, 350.0, PARTITION_SOLID_EDICTS, Items_FragTrace);
 		
 		AcceptEntityInput(entity, "Kill");

--- a/addons/sourcemod/scripting/scp_sf/items.sp
+++ b/addons/sourcemod/scripting/scp_sf/items.sp
@@ -1686,7 +1686,6 @@ public bool Items_FragButton(int client, int weapon, int &buttons, int &holding)
 	return false;
 }
 
-//float FragPos[3];
 bool Items_FragTrace(int entity)
 {
 	// things like static props do go through, ignore them
@@ -1697,26 +1696,7 @@ bool Items_FragTrace(int entity)
 	if (GetEntityClassname(entity, buffer, sizeof(buffer))) 
 	{
 		if (!strncmp(buffer, "func_door", 9, false))
-		{
 			DestroyOrOpenDoor(entity);
-		}
-		//else if (!strncmp(buffer, "tf_drop", 9, false))
-		//{
-			// try push away weapons
-			// TODO: this will need a vphysics extension, as the objects are asleep and hence can't be moved otherwise
-		
-			//float pos2[3], delta[3], dist;
-			//GetEntPropVector(entity, Prop_Send, "m_vecOrigin", pos2);
-			//SubtractVectors(pos2, FragPos, delta);
-			//dist = GetVectorLength(delta, false);		
-			// apply falloff depending on distance
-			//float falloff = (dist / 350.0);
-			//if (falloff != 0.0)
-			//{
-			//	ScaleVector(delta, 1.0 - falloff);
-			//	TeleportEntity(entity, NULL_VECTOR, NULL_VECTOR, delta);
-			//}			
-		//}
 	}
 	
 	return true;
@@ -1742,14 +1722,14 @@ public Action Items_FragTimer(Handle timer, int ref)
 			// pass the original class of the thrower
 			SetEntProp(explosion, Prop_Data, "m_iHammerID", GetEntProp(entity, Prop_Data, "m_iHammerID"));	
 			
-			AcceptEntityInput(explosion, "Explode");
+			// find any doors nearby and try destroy or force them open
 			TR_EnumerateEntitiesSphere(pos, 350.0, PARTITION_SOLID_EDICTS, Items_FragTrace);
+			
+			AcceptEntityInput(explosion, "Explode");
 			CreateTimer(0.1, Timer_RemoveEntity, EntIndexToEntRef(explosion), TIMER_FLAG_NO_MAPCHANGE);
 		}
 		
 		RemoveEntity(entity);
-		// find any doors nearby and try destroy or force them open
-		//CopyVector(pos, FragPos); // temporary for trace, used for pushing items away
 	}
 	return Plugin_Continue;
 }

--- a/addons/sourcemod/scripting/scp_sf/items.sp
+++ b/addons/sourcemod/scripting/scp_sf/items.sp
@@ -1689,6 +1689,9 @@ public bool Items_FragButton(int client, int weapon, int &buttons, int &holding)
 //float FragPos[3];
 bool Items_FragTrace(int entity)
 {
+	if (!IsValidEntity(entity))
+		return true;
+	
 	char buffer[10];
 	if (GetEntityClassname(entity, buffer, sizeof(buffer))) 
 	{
@@ -1734,7 +1737,7 @@ public Action Items_FragTimer(Handle timer, int ref)
 			DispatchKeyValue(explosion, "iMagnitude", "500");
 			DispatchKeyValue(explosion, "iRadiusOverride", "350");
 			// don't want particles or sound, we create them seperately
-			DispatchKeyValue(explosion, "spawnflags", "916");
+			DispatchKeyValue(explosion, "spawnflags", "978");
 			
 			SetEntPropEnt(explosion, Prop_Data, "m_hOwnerEntity", client);
 			// pass the original class of the thrower
@@ -1746,25 +1749,16 @@ public Action Items_FragTimer(Handle timer, int ref)
 			SetVariantString("classname taunt_soldier"); 
 			AcceptEntityInput(explosion, "AddOutput");
 			
-			int particle = AttachParticle(explosion, "asplode_hoodoo", false, 5.0);
-			if (particle)
-				EmitGameSoundToAll("Weapon_Airstrike.Explosion", particle, entity, _, _, pos);
-				
+			AttachParticle(explosion, "asplode_hoodoo", false, 5.0);
+			EmitGameSoundToAll("Weapon_Airstrike.Explosion", entity);
+			
 			AcceptEntityInput(explosion, "Explode");
 			CreateTimer(0.1, Timer_RemoveEntity, EntIndexToEntRef(explosion), TIMER_FLAG_NO_MAPCHANGE);
 		}
-		
+
 		// find any doors nearby and try destroy or force them open
 		//CopyVector(pos, FragPos); // temporary for trace
-		
-		// FIXME: switch to this method when SM 1.11 is stablew
-		//TR_EnumerateEntitiesSphere(pos, 350.0, PARTITION_SOLID_EDICTS, Items_FragTrace);
-		
-		int entitytrace = -1;
-		while ((entitytrace = SDKCall_FindEntityInSphere(entitytrace, pos, 350.0)) != -1)
-		{
-			Items_FragTrace(entitytrace);
-		}
+		TR_EnumerateEntitiesSphere(pos, 350.0, PARTITION_SOLID_EDICTS, Items_FragTrace);
 		
 		AcceptEntityInput(entity, "Kill");
 	}
@@ -1853,7 +1847,7 @@ public Action Items_FlashTimer(Handle timer, int ref)
 			if (light > MaxClients)
 				TeleportEntity(light, pos1, view_as<float>({ 90.0, 0.0, 0.0 }), NULL_VECTOR);
 			
-			AcceptEntityInput(explosion, "Detonate");
+			AcceptEntityInput(explosion, "Explode");
 			CreateTimer(0.1, Timer_RemoveEntity, EntIndexToEntRef(explosion), TIMER_FLAG_NO_MAPCHANGE);
 		}
 

--- a/addons/sourcemod/scripting/scp_sf/sdkcalls.sp
+++ b/addons/sourcemod/scripting/scp_sf/sdkcalls.sp
@@ -6,7 +6,6 @@ Handle SDKCreateWeapon;
 Handle SDKInitWeapon;
 static Handle SDKInitPickup;
 static Handle SDKSetSpeed;
-static Handle SDKFindEntityInSphere;
 static Handle SDKFindCriterionIndex;
 static Handle SDKRemoveCriteria;
 
@@ -75,14 +74,6 @@ void SDKCall_Setup(GameData gamedata)
 	SDKSetSpeed = EndPrepSDKCall();
 	if(!SDKSetSpeed)
 		LogError("[Gamedata] Could not find CTFPlayer::TeamFortress_SetSpeed");
-		
-	StartPrepSDKCall(SDKCall_EntityList);
-	PrepSDKCall_SetFromConf(gamedata, SDKConf_Signature, "CGlobalEntityList::FindEntityInSphere()");
-	PrepSDKCall_SetReturnInfo(SDKType_CBaseEntity, SDKPass_Pointer);
-	PrepSDKCall_AddParameter(SDKType_CBaseEntity, SDKPass_Pointer, VDECODE_FLAG_ALLOWNULL | VDECODE_FLAG_ALLOWWORLD);
-	PrepSDKCall_AddParameter(SDKType_Vector, SDKPass_ByRef);
-	PrepSDKCall_AddParameter(SDKType_Float, SDKPass_Plain);
-	SDKFindEntityInSphere = EndPrepSDKCall();
 	
 	StartPrepSDKCall(SDKCall_Raw);
 	PrepSDKCall_SetFromConf(gamedata, SDKConf_Signature, "AI_CriteriaSet::FindCriterionIndex");
@@ -182,10 +173,4 @@ void SDKCall_RemoveCriteria(int criteriaSet, const char[] criteria)
 {
 	if (SDKRemoveCriteria)
 		SDKCall(SDKRemoveCriteria, criteriaSet, criteria);
-}
-
-// FIXME: remove this when SM 1.11 is stable (TR_EnumerateEntitiesSphere can be used instead)
-int SDKCall_FindEntityInSphere(int startEntity, const float vecPosition[3], float flRadius) 
-{
-	return SDKCall(SDKFindEntityInSphere, startEntity, vecPosition, flRadius);
 }


### PR DESCRIPTION
Frag Grenade:
- Method of detection for door destruction now uses `TR_EnumerateEntitiesSphere` (addresses #94)
- Fixed the default explosion sound playing, then the expected sound to play not working half the time

If there's any other kind of effect anyone would like to see (such as a subtle shake), let me know

Flash Grenade:
- Fixed the explosion entity not actually exploding (oops!)
    - ...not that it matters much, all the explosion does is add a little fireball effect (not the same thing as the explosion particle), which I guess is fine to keep