### PR TITLE
Allow players to throw items

### DIFF
--- a/addons/sourcemod/scripting/scp_sf.sp
+++ b/addons/sourcemod/scripting/scp_sf.sp
@@ -1386,8 +1386,9 @@ public Action OnDropItem(int client, const char[] command, int args)
 			if(entity > MaxClients)
 			{
 				WeaponEnum weapon;
-				bool big = (Items_GetWeaponByIndex(GetEntProp(entity, Prop_Send, "m_iItemDefinitionIndex"), weapon) && weapon.Type==ITEM_TYPE_WEAPON);
+				int index = GetEntProp(entity, Prop_Send, "m_iItemDefinitionIndex");
 				int dropType = GetEntityFlags(client) & FL_DUCKING ? ItemDrop_Drop : ItemDrop_Throw;
+				bool big = ((Items_GetWeaponByIndex(index, weapon) && weapon.Type==ITEM_TYPE_WEAPON) || index == ITEM_INDEX_MICROHID);
 				
 				static float pos[3], ang[3];
 				GetClientEyePosition(client, pos);

--- a/addons/sourcemod/scripting/scp_sf.sp
+++ b/addons/sourcemod/scripting/scp_sf.sp
@@ -1387,11 +1387,13 @@ public Action OnDropItem(int client, const char[] command, int args)
 			{
 				WeaponEnum weapon;
 				bool big = (Items_GetWeaponByIndex(GetEntProp(entity, Prop_Send, "m_iItemDefinitionIndex"), weapon) && weapon.Type==ITEM_TYPE_WEAPON);
-
+				int dropType = GetEntityFlags(client) & FL_DUCKING ? ItemDrop_Drop : ItemDrop_Throw;
+				
 				static float pos[3], ang[3];
 				GetClientEyePosition(client, pos);
 				GetClientEyeAngles(client, ang);
-				if(Items_DropItem(client, entity, pos, ang, true))
+				
+				if(Items_DropItem(client, entity, pos, ang, true, dropType))
 				{
 					if(big)
 					{

--- a/addons/sourcemod/scripting/scp_sf.sp
+++ b/addons/sourcemod/scripting/scp_sf.sp
@@ -1397,7 +1397,7 @@ public Action OnDropItem(int client, const char[] command, int args)
 				{
 					if(big)
 					{
-						ClientCommand(client, "playgamesound BaseCombatWeapon.WeaponDrop");
+						ClientCommand(client, "playgamesound ui/item_bag_drop.wav");	// No accompanying GameSound, but this works
 					}
 					else
 					{

--- a/addons/sourcemod/scripting/scp_sf/items.sp
+++ b/addons/sourcemod/scripting/scp_sf/items.sp
@@ -900,8 +900,8 @@ bool Items_DropItem(int client, int helditem, const float origin[3], const float
 				
 				case ItemDrop_Scatter:	// throw in a random-ish direction
 				{
-					vel[0] = float(GetRandomInt(-150, 150));
-					vel[1] = float(GetRandomInt(-150, 150));
+					vel[0] = float(GetRandomInt(-100, 100));
+					vel[1] = float(GetRandomInt(-100, 100));
 					vel[2] = float(GetRandomInt(25, 100));
 				}
 			}

--- a/addons/sourcemod/scripting/scp_sf/items.sp
+++ b/addons/sourcemod/scripting/scp_sf/items.sp
@@ -884,14 +884,18 @@ bool Items_DropItem(int client, int helditem, const float origin[3], const float
 			{
 				case ItemDrop_Throw:	// throw in the direction the player is looking at
 				{
-					// check if we're too close to a wall, just drop it if so
+					// check if we're too close to a wall
 					float posFinal[3];
 					TR_TraceRayFilter(origin, angles, MASK_SOLID, RayType_Infinite, Trace_WorldAndBrushes);
 					TR_GetEndPosition(posFinal);
-				
-					// 48 units
-					if (GetVectorDistance(origin, posFinal, true) > 2304.0)
-						Items_GrenadeTrajectory(angles, vel, 300.0);	// just reuse this, I guess
+					
+					// if we are too close, weaken the throw
+					float distance = GetVectorDistance(origin, posFinal, false);
+					
+					if (distance > 200.0)
+						distance = 200.0
+					
+					Items_GrenadeTrajectory(angles, vel, (distance * 1.5));	// just reuse this, I guess
 				}
 				
 				case ItemDrop_Scatter:	// throw in a random-ish direction

--- a/addons/sourcemod/scripting/scp_sf/items.sp
+++ b/addons/sourcemod/scripting/scp_sf/items.sp
@@ -745,7 +745,7 @@ bool Items_CanGiveItem(int client, int type, bool &full=false)
 	return true;
 }
 
-bool Items_DropItem(int client, int helditem, const float origin[3], const float angles[3], bool swap=true, int dropType = ItemDrop_Drop)
+bool Items_DropItem(int client, int helditem, const float origin[3], const float angles[3], bool swap = true, int dropType = ItemDrop_Drop)
 {
 	static char buffer[PLATFORM_MAX_PATH];
 	GetEntityNetClass(helditem, buffer, sizeof(buffer));


### PR DESCRIPTION
Just a nice little thing. Players will gently throw items instead of dropping them, except if they're crouching, then it'll work as it always has.

In cases where players drop all of their items at once, such as dying or escaping, items will be slightly scattered around at  random, so things likely won't be on top of each other.

~~Only problem I can think of is that players can throw items through doors from a respectable distance, as items can't block them for obvious reasons. Is that problematic enough to consider working around?~~ Addressed.

[Throwing preview](https://cdn.discordapp.com/attachments/537258632069382144/1006142337455509544/2022-08-08_07-09-50.mp4) and [scattering preview](https://cdn.discordapp.com/attachments/332809334339665930/1006611627375853719/2022-08-09_14-14-08.mp4) (they're downloadable videos)

To do: ~~maybe find a more suitable sound for dropping weapons, as it plays a pretty distinct impact-on-surface sound at the moment.~~ Addressed. Now uses `ui/item_bag_drop.wav`