### PR TITLE
Remove lag compensation code

### DIFF
--- a/addons/sourcemod/gamedata/scp_sf.txt
+++ b/addons/sourcemod/gamedata/scp_sf.txt
@@ -180,28 +180,6 @@
 				"return"	"void"
 				"this"		"entity"
 			}
-			"CBasePlayer::WantsLagCompensationOnEntity"
-			{
-				"offset"	"CBasePlayer::WantsLagCompensationOnEntity"
-				"hooktype"	"entity"
-				"return"	"bool"
-				"this"		"entity"
-				"arguments"
-				{
-					"pPlayer"
-					{
-						"type"	"cbaseentity"
-					}
-					"pCmd"
-					{
-						"type"	"objectptr"
-					}
-					"pEntityTransmitBits"
-					{
-						"type"	"objectptr"
-					}
-				}
-			}
 			"CTeamplayRoundBasedRules::RoundRespawn"
 			{
 				"offset"	"CTeamplayRoundBasedRules::RoundRespawn"
@@ -413,11 +391,6 @@
 			{
 				"linux"		"337"
 				"windows"	"336"
-			}
-			"CBasePlayer::WantsLagCompensationOnEntity"
-			{
-				"linux"		"335"
-				"windows"	"334"
 			}
 			"CTeamplayRoundBasedRules::RoundRespawn"
 			{

--- a/addons/sourcemod/scripting/scp_sf/dhooks.sp
+++ b/addons/sourcemod/scripting/scp_sf/dhooks.sp
@@ -5,16 +5,12 @@ static DynamicDetour AllowedToHealTarget;
 static DynamicHook RoundRespawn;
 static DynamicHook ShouldCollide;
 static DynamicHook ForceRespawn;
-static DynamicHook WantsLagCompensationOnEntity;
 static DynamicHook ModifyOrAppendCriteria;
 static int ShouldCollidePreHook[MAXTF2PLAYERS];
 static int ForceRespawnPreHook[MAXTF2PLAYERS];
 static int ForceRespawnPostHook[MAXTF2PLAYERS];
-static int WantsLagCompensationOnEntityPreHook[MAXTF2PLAYERS];
-static int WantsLagCompensationOnEntityPostHook[MAXTF2PLAYERS];
 static int ModifyOrAppendCriteriaPostHook[MAXTF2PLAYERS];
 static int CalculateSpeedClient;
-static int ClientTeam[MAXTF2PLAYERS];
 
 int StudioHdrOffset;
 
@@ -64,10 +60,6 @@ void DHook_Setup(GameData gamedata)
 	if(!ForceRespawn)
 		LogError("[Gamedata] Could not find CBasePlayer::ForceRespawn");
 	
-	WantsLagCompensationOnEntity = DynamicHook.FromConf(gamedata, "CBasePlayer::WantsLagCompensationOnEntity");
-	if(!WantsLagCompensationOnEntity)
-		LogError("[Gamedata] Could not find CBasePlayer::WantsLagCompensationOnEntity");
-	
 	ModifyOrAppendCriteria = DynamicHook.FromConf(gamedata, "CBaseEntity::ModifyOrAppendCriteria");
 	if(!ModifyOrAppendCriteria)
 		LogError("[Gamedata] Could not find CBaseEntity::ModifyOrAppendCriteria");
@@ -109,12 +101,6 @@ void DHook_HookClient(int client)
 		ForceRespawnPostHook[client] = ForceRespawn.HookEntity(Hook_Post, client, DHook_ForceRespawnPost);
 	}
 	
-	if(WantsLagCompensationOnEntity)
-	{
-		WantsLagCompensationOnEntityPreHook[client] = WantsLagCompensationOnEntity.HookEntity(Hook_Pre, client, DHook_WantsLagCompensationOnEntityPre);
-		WantsLagCompensationOnEntityPostHook[client] = WantsLagCompensationOnEntity.HookEntity(Hook_Post, client, DHook_WantsLagCompensationOnEntityPost);
-	}
-	
 	if(ModifyOrAppendCriteria)
 	{
 		ModifyOrAppendCriteriaPostHook[client] = ModifyOrAppendCriteria.HookEntity(Hook_Post, client, DHook_ModifyOrAppendCriteriaPost);
@@ -126,8 +112,6 @@ void DHook_UnhookClient(int client)
 	DynamicHook.RemoveHook(ShouldCollidePreHook[client]);
 	DynamicHook.RemoveHook(ForceRespawnPreHook[client]);
 	DynamicHook.RemoveHook(ForceRespawnPostHook[client]);
-	DynamicHook.RemoveHook(WantsLagCompensationOnEntityPreHook[client]);
-	DynamicHook.RemoveHook(WantsLagCompensationOnEntityPostHook[client]);
 	DynamicHook.RemoveHook(ModifyOrAppendCriteriaPostHook[client]);
 }
 
@@ -221,29 +205,6 @@ public MRESReturn DHook_ForceRespawnPost(int client)
 	if(Client[client].PrefClass != TFClass_Unknown)
 		SetEntProp(client, Prop_Send, "m_iDesiredPlayerClass", Client[client].PrefClass);
 	return MRES_Ignored;
-}
-
-public MRESReturn DHook_WantsLagCompensationOnEntityPre(int client, DHookReturn ret, DHookParam param)
-{
-	int player = param.Get(1);
-	
-	ClientTeam[client] = GetClientTeam(client);
-	ClientTeam[player] = GetClientTeam(player);
-	
-	ChangeClientTeamEx(client, TFTeam_Red);
-	ChangeClientTeamEx(player, TFTeam_Blue);
-	return MRES_Ignored;
-}
-
-public MRESReturn DHook_WantsLagCompensationOnEntityPost(int client, DHookReturn ret, DHookParam param)
-{
-	int player = param.Get(1);
-	
-	ChangeClientTeamEx(client, ClientTeam[client]);
-	ChangeClientTeamEx(player, ClientTeam[player]);
-	
-	ret.Value = ret.Value || !IsFriendly(Client[client].Class, Client[player].Class);
-	return MRES_Supercede;
 }
 
 public MRESReturn DHook_CanPickupDroppedWeaponPre(int client, DHookReturn ret, DHookParam param)


### PR DESCRIPTION
A recent TF2 update makes this redundant as long as `mp_friendlyfire` is set, which the gamemode always does