### PR TITLE
Update config to support unlimited players

### DIFF
--- a/addons/sourcemod/configs/scp_sf/gamemode.cfg
+++ b/addons/sourcemod/configs/scp_sf/gamemode.cfg
@@ -76,7 +76,7 @@
 		"set_any"
 		{
 			// For every SCP, 8 more humans
-			"type"	"Gamemode_PresentOrder"	// Select in this order, looping
+			"type"	"Gamemode_PresetOrdered"	// Select in this order, looping
 			"1"	"set_scp"
 			"2"	"set_human"
 			"3"	"set_human"

--- a/addons/sourcemod/configs/scp_sf/gamemode.cfg
+++ b/addons/sourcemod/configs/scp_sf/gamemode.cfg
@@ -26,7 +26,7 @@
 		"20"	"scp9392"
 	}
 
-	"setup"	// Goes up to 32 players
+	"setup"
 	{
 		"1"	"dboi"
 		"2"	"dboi"
@@ -38,28 +38,7 @@
 		"8"	"set_human"
 		"9"	"set_human"
 		"10"	"set_human"
-		"11"	"set_scp"
-		"12"	"set_human"
-		"13"	"set_human"
-		"14"	"set_human"
-		"15"	"set_human"
-		"16"	"set_human"
-		"17"	"set_human"
-		"18"	"set_human"
-		"19"	"set_red"
-		"20"	"set_human"
-		"21"	"set_human"
-		"22"	"set_human"
-		"23"	"set_human"
-		"24"	"set_human"
-		"25"	"set_human"
-		"26"	"set_human"
-		"27"	"set_human"
-		"28"	"set_scp"
-		"29"	"set_human"
-		"30"	"set_human"
-		"31"	"set_human"
-		"32"	"set_human"
+		"11"	"set_any"
 	}
 
 	"waves"	// Respawn waves
@@ -76,37 +55,7 @@
 			"trigger"		"scp_chaos_spawn"
 			"trigger_pre"	"scp_chaos_spawn_pre"
 			
-			"1"		"chaos1"
-			"2"		"chaos1"
-			"3"		"chaos1"
-			"4"		"chaos2"
-			"5"		"chaos3"
-			"6"		"chaos1"
-			"7"		"chaos2"
-			"8"		"chaos1"
-			"9"		"chaos2"
-			"10"		"chaos3"
-			"11"		"chaos1"
-			"12"		"chaos1"
-			"13"		"chaos2"
-			"14"		"chaos1"
-			"15"		"chaos3"
-			"16"		"chaos1"
-			"17"		"chaos2"
-			"18"		"chaos1"
-			"19"		"chaos2"
-			"20"		"chaos3"
-			"21"		"chaos1"
-			"22"		"chaos1"
-			"23"		"chaos2"
-			"24"		"chaos1"
-			"25"		"chaos3"
-			"26"		"chaos1"
-			"27"		"chaos2"
-			"28"		"chaos1"
-			"29"		"chaos2"
-			"30"		"chaos3"
-			"31"		"chaos1"
+			"1"		"set_chaos"
 		}
 		"2"
 		{
@@ -124,6 +73,20 @@
 
 	"presets"	// Class sets to pull from
 	{
+		"set_any"
+		{
+			// For every SCP, 8 more humans
+			"type"	"Gamemode_PresentOrder"	// Select in this order, looping
+			"1"	"set_scp"
+			"2"	"set_human"
+			"3"	"set_human"
+			"4"	"set_human"
+			"5"	"set_human"
+			"6"	"set_human"
+			"7"	"set_human"
+			"8"	"set_human"
+			"9"	"set_human"
+		}
 		"set_human"
 		{
 			"type"	"Gamemode_PresetRandom"	// Choose randomly
@@ -161,6 +124,14 @@
 			"1"	"mtf1"
 			"2"	"mtf1"
 			"3"	"mtf2"
+		}
+		"set_chaos"
+		{
+			"type"	"Gamemode_PresetRandom"	// Choose randomly
+			"1"	"chaos1"
+			"2"	"chaos1"
+			"3"	"chaos2"
+			"4"	"chaos3"
 		}
 	}
 

--- a/addons/sourcemod/configs/scp_sf/maps/scp_3008.cfg
+++ b/addons/sourcemod/configs/scp_sf/maps/scp_3008.cfg
@@ -53,7 +53,7 @@
 		{
 			"set_any"
 			{
-				"type"	"Gamemode_PresentOrder"	// Select in this order, looping
+				"type"	"Gamemode_PresetOrdered"	// Select in this order, looping
 				"1"	"scp3008"
 				"2"	"set_ikea"
 				"3"	"ikea1"

--- a/addons/sourcemod/configs/scp_sf/maps/scp_3008.cfg
+++ b/addons/sourcemod/configs/scp_sf/maps/scp_3008.cfg
@@ -18,40 +18,11 @@
 			"9"	"scp3008"
 		}
 
-		"setup"	// Goes up to 32 players
+		"setup"
 		{
 			"1"	"ikea1"
 			"2"	"ikea1"
-			"3"	"scp3008"
-			"4"	"ikea1"
-			"5"	"ikea1"
-			"6"	"ikea1"
-			"7"	"ikea2"
-			"8"	"scp3008"
-			"9"	"ikea1"
-			"10"	"ikea1"
-			"11"	"ikea1"
-			"12"	"ikea2"
-			"13"	"scp3008"
-			"14"	"ikea1"
-			"15"	"ikea1"
-			"16"	"ikea1"
-			"17"	"ikea2"
-			"18"	"scp3008"
-			"19"	"ikea3"
-			"20"	"ikea1"
-			"21"	"ikea1"
-			"22"	"ikea2"
-			"23"	"scp3008"
-			"24"	"ikea1"
-			"25"	"ikea1"
-			"26"	"ikea1"
-			"27"	"ikea2"
-			"28"	"scp3008"
-			"29"	"ikea3"
-			"30"	"ikea1"
-			"31"	"ikea1"
-			"32"	"ikea2"
+			"3"	"set_any"
 		}
 
 		"waves"	// Respawn waves
@@ -75,6 +46,26 @@
 				"4"		"mtf1"
 				"5"		"mtf2"
 				"6"		"mtf1"
+			}
+		}
+		
+		"presets"	// Class sets to pull from
+		{
+			"set_any"
+			{
+				"type"	"Gamemode_PresentOrder"	// Select in this order, looping
+				"1"	"scp3008"
+				"2"	"set_ikea"
+				"3"	"ikea1"
+				"4"	"ikea1"
+				"5"	"ikea2"
+			}
+			"set_ikea"
+			{
+				"type"	"Gamemode_PresetRandom"	// Choose randomly
+				"1"	"ikea1"
+				"1"	"ikea1"
+				"2"	"ikea3"
 			}
 		}
 	}

--- a/addons/sourcemod/configs/scp_sf/maps/scp_abandoned.cfg
+++ b/addons/sourcemod/configs/scp_sf/maps/scp_abandoned.cfg
@@ -27,7 +27,7 @@
 			"19"	"scp9392"
 		}
 
-		"setup"	// Goes up to 32 players
+		"setup"
 		{
 			"1"	"dboi"
 			"2"	"dboi"
@@ -39,28 +39,7 @@
 			"8"	"set_human"
 			"9"	"set_human"
 			"10"	"set_human"
-			"11"	"set_scp"
-			"12"	"set_human"
-			"13"	"set_human"
-			"14"	"set_human"
-			"15"	"set_human"
-			"16"	"set_human"
-			"17"	"set_human"
-			"18"	"set_human"
-			"19"	"set_red"
-			"20"	"set_human"
-			"21"	"set_human"
-			"22"	"set_human"
-			"23"	"set_human"
-			"24"	"set_human"
-			"25"	"set_human"
-			"26"	"set_human"
-			"27"	"set_human"
-			"28"	"set_scp"
-			"29"	"set_human"
-			"30"	"set_human"
-			"31"	"set_human"
-			"32"	"set_human"
+			"11"	"set_any"
 		}
 
 		"waves"	// Respawn waves
@@ -77,37 +56,7 @@
 				"trigger"		"scp_chaos_spawn"
 				"trigger_pre"	"scp_chaos_spawn_pre"
 				
-				"1"		"chaos1"
-				"2"		"chaos1"
-				"3"		"chaos1"
-				"4"		"chaos2"
-				"5"		"chaos3"
-				"6"		"chaos1"
-				"7"		"chaos2"
-				"8"		"chaos1"
-				"9"		"chaos2"
-				"10"		"chaos3"
-				"11"		"chaos1"
-				"12"		"chaos1"
-				"13"		"chaos2"
-				"14"		"chaos1"
-				"15"		"chaos3"
-				"16"		"chaos1"
-				"17"		"chaos2"
-				"18"		"chaos1"
-				"19"		"chaos2"
-				"20"		"chaos3"
-				"21"		"chaos1"
-				"22"		"chaos1"
-				"23"		"chaos2"
-				"24"		"chaos1"
-				"25"		"chaos3"
-				"26"		"chaos1"
-				"27"		"chaos2"
-				"28"		"chaos1"
-				"29"		"chaos2"
-				"30"		"chaos3"
-				"31"		"chaos1"
+				"1"		"set_chaos"
 			}
 			"2"
 			{
@@ -125,6 +74,20 @@
 
 		"presets"	// Class sets to pull from
 		{
+			"set_any"
+			{
+				// For every SCP, 8 more humans
+				"type"	"Gamemode_PresentOrder"	// Select in this order, looping
+				"1"	"set_scp"
+				"2"	"set_human"
+				"3"	"set_human"
+				"4"	"set_human"
+				"5"	"set_human"
+				"6"	"set_human"
+				"7"	"set_human"
+				"8"	"set_human"
+				"9"	"set_human"
+			}
 			"set_human"
 			{
 				"type"	"Gamemode_PresetRandom"	// Choose randomly
@@ -162,6 +125,14 @@
 				"1"	"mtf1"
 				"2"	"mtf1"
 				"3"	"mtf2"
+			}
+			"set_chaos"
+			{
+				"type"	"Gamemode_PresetRandom"	// Choose randomly
+				"1"	"chaos1"
+				"2"	"chaos1"
+				"3"	"chaos2"
+				"4"	"chaos3"
 			}
 		}
 

--- a/addons/sourcemod/configs/scp_sf/maps/scp_abandoned.cfg
+++ b/addons/sourcemod/configs/scp_sf/maps/scp_abandoned.cfg
@@ -77,7 +77,7 @@
 			"set_any"
 			{
 				// For every SCP, 8 more humans
-				"type"	"Gamemode_PresentOrder"	// Select in this order, looping
+				"type"	"Gamemode_PresetOrdered"	// Select in this order, looping
 				"1"	"set_scp"
 				"2"	"set_human"
 				"3"	"set_human"

--- a/addons/sourcemod/configs/scp_sf/maps/scp_fortress.cfg
+++ b/addons/sourcemod/configs/scp_sf/maps/scp_fortress.cfg
@@ -75,7 +75,7 @@
 			"set_any"
 			{
 				// For every SCP, 8 more humans
-				"type"	"Gamemode_PresentOrder"	// Select in this order, looping
+				"type"	"Gamemode_PresetOrdered"	// Select in this order, looping
 				"1"	"set_scp"
 				"2"	"set_human"
 				"3"	"set_human"

--- a/addons/sourcemod/configs/scp_sf/maps/scp_fortress.cfg
+++ b/addons/sourcemod/configs/scp_sf/maps/scp_fortress.cfg
@@ -25,7 +25,7 @@
 			"17"	"scp9392"
 		}
 
-		"setup"	// Goes up to 32 players
+		"setup"
 		{
 			"1"	"dboi"
 			"2"	"dboi"
@@ -37,28 +37,7 @@
 			"8"	"set_human"
 			"9"	"set_human"
 			"10"	"set_human"
-			"11"	"set_scp"
-			"12"	"set_human"
-			"13"	"set_human"
-			"14"	"set_human"
-			"15"	"set_human"
-			"16"	"set_human"
-			"17"	"set_human"
-			"18"	"set_human"
-			"19"	"set_red"
-			"20"	"set_human"
-			"21"	"set_human"
-			"22"	"set_human"
-			"23"	"set_human"
-			"24"	"set_human"
-			"25"	"set_human"
-			"26"	"set_human"
-			"27"	"set_human"
-			"28"	"set_scp"
-			"29"	"set_human"
-			"30"	"set_human"
-			"31"	"set_human"
-			"32"	"set_human"
+			"11"	"set_any"
 		}
 
 		"waves"	// Respawn waves
@@ -75,37 +54,7 @@
 				"trigger"		"scp_chaos_spawn"
 				"trigger_pre"	"scp_chaos_spawn_pre"
 				
-				"1"		"chaos1"
-				"2"		"chaos1"
-				"3"		"chaos1"
-				"4"		"chaos2"
-				"5"		"chaos3"
-				"6"		"chaos1"
-				"7"		"chaos2"
-				"8"		"chaos1"
-				"9"		"chaos2"
-				"10"		"chaos3"
-				"11"		"chaos1"
-				"12"		"chaos1"
-				"13"		"chaos2"
-				"14"		"chaos1"
-				"15"		"chaos3"
-				"16"		"chaos1"
-				"17"		"chaos2"
-				"18"		"chaos1"
-				"19"		"chaos2"
-				"20"		"chaos3"
-				"21"		"chaos1"
-				"22"		"chaos1"
-				"23"		"chaos2"
-				"24"		"chaos1"
-				"25"		"chaos3"
-				"26"		"chaos1"
-				"27"		"chaos2"
-				"28"		"chaos1"
-				"29"		"chaos2"
-				"30"		"chaos3"
-				"31"		"chaos1"
+				"1"		"set_chaos"
 			}
 			"2"
 			{
@@ -123,6 +72,20 @@
 
 		"presets"	// Class sets to pull from
 		{
+			"set_any"
+			{
+				// For every SCP, 8 more humans
+				"type"	"Gamemode_PresentOrder"	// Select in this order, looping
+				"1"	"set_scp"
+				"2"	"set_human"
+				"3"	"set_human"
+				"4"	"set_human"
+				"5"	"set_human"
+				"6"	"set_human"
+				"7"	"set_human"
+				"8"	"set_human"
+				"9"	"set_human"
+			}
 			"set_human"
 			{
 				"type"	"Gamemode_PresetRandom"	// Choose randomly
@@ -158,6 +121,14 @@
 				"1"	"mtf1"
 				"2"	"mtf1"
 				"3"	"mtf2"
+			}
+			"set_chaos"
+			{
+				"type"	"Gamemode_PresetRandom"	// Choose randomly
+				"1"	"chaos1"
+				"2"	"chaos1"
+				"3"	"chaos2"
+				"4"	"chaos3"
 			}
 		}
 

--- a/addons/sourcemod/configs/scp_sf/maps/scp_frostbite.cfg
+++ b/addons/sourcemod/configs/scp_sf/maps/scp_frostbite.cfg
@@ -29,39 +29,19 @@
 			"21"	"saxtron"
 		}
 
-		"setup"	// Goes up to 32 players
+		"setup"
 		{
 			"1"	"dboi"
-			"2"	"sci"
-			"3"	"set_scp"
-			"4"	"set_human"
+			"2"	"dboi"
+			"3"	"sci"
+			"4"	"set_scp"
 			"5"	"set_human"
 			"6"	"set_human"
 			"7"	"set_human"
 			"8"	"set_human"
 			"9"	"set_human"
 			"10"	"set_human"
-			"11"	"set_human"
-			"12"	"set_scp"
-			"13"	"set_human"
-			"14"	"set_human"
-			"15"	"set_human"
-			"16"	"set_human"
-			"17"	"set_human"
-			"18"	"set_human"
-			"19"	"set_human"
-			"20"	"set_human"
-			"21"	"set_scp"
-			"22"	"set_human"
-			"23"	"set_human"
-			"24"	"set_human"
-			"25"	"set_human"
-			"26"	"set_human"
-			"27"	"set_human"
-			"28"	"set_human"
-			"29"	"set_human"
-			"30"	"set_scp"
-			"31"	"set_human"
+			"11"	"set_any"
 		}
 
 		"waves"	// Respawn waves
@@ -73,37 +53,7 @@
 			{
 				"tickets"	"14"
 
-				"1"		"chaos1"
-				"2"		"chaos1"
-				"3"		"chaos1"
-				"4"		"chaos2"
-				"5"		"chaos3"
-				"6"		"chaos1"
-				"7"		"chaos2"
-				"8"		"chaos1"
-				"9"		"chaos2"
-				"10"		"chaos3"
-				"11"		"chaos1"
-				"12"		"chaos1"
-				"13"		"chaos2"
-				"14"		"chaos1"
-				"15"		"chaos3"
-				"16"		"chaos1"
-				"17"		"chaos2"
-				"18"		"chaos1"
-				"19"		"chaos2"
-				"20"		"chaos3"
-				"21"		"chaos1"
-				"22"		"chaos1"
-				"23"		"chaos2"
-				"24"		"chaos1"
-				"25"		"chaos3"
-				"26"		"chaos1"
-				"27"		"chaos2"
-				"28"		"chaos1"
-				"29"		"chaos2"
-				"30"		"chaos3"
-				"31"		"chaos1"
+				"1"		"set_chaos"
 			}
 			"2"
 			{
@@ -149,6 +99,20 @@
 
 		"presets"	// Class sets to pull from
 		{
+			"set_any"
+			{
+				// For every SCP, 8 more humans
+				"type"	"Gamemode_PresentOrder"	// Select in this order, looping
+				"1"	"set_scp"
+				"2"	"set_human"
+				"3"	"set_human"
+				"4"	"set_human"
+				"5"	"set_human"
+				"6"	"set_human"
+				"7"	"set_human"
+				"8"	"set_human"
+				"9"	"set_human"
+			}
 			"set_human"
 			{
 				"type"	"Gamemode_PresetRandom"	// Choose randomly
@@ -172,6 +136,14 @@
 				"1"	"mtf1"
 				"2"	"mtf1"
 				"3"	"mtf2"
+			}
+			"set_chaos"
+			{
+				"type"	"Gamemode_PresetRandom"	// Choose randomly
+				"1"	"chaos1"
+				"2"	"chaos1"
+				"3"	"chaos2"
+				"4"	"chaos3"
 			}
 		}
 

--- a/addons/sourcemod/configs/scp_sf/maps/scp_frostbite.cfg
+++ b/addons/sourcemod/configs/scp_sf/maps/scp_frostbite.cfg
@@ -102,7 +102,7 @@
 			"set_any"
 			{
 				// For every SCP, 8 more humans
-				"type"	"Gamemode_PresentOrder"	// Select in this order, looping
+				"type"	"Gamemode_PresetOrdered"	// Select in this order, looping
 				"1"	"set_scp"
 				"2"	"set_human"
 				"3"	"set_human"

--- a/addons/sourcemod/configs/scp_sf/maps/scp_mandrillmaze.cfg
+++ b/addons/sourcemod/configs/scp_sf/maps/scp_mandrillmaze.cfg
@@ -65,7 +65,7 @@
 			"set_any"
 			{
 				// For every SCP, 8 more humans
-				"type"	"Gamemode_PresentOrder"	// Select in this order, looping
+				"type"	"Gamemode_PresetOrdered"	// Select in this order, looping
 				"1"	"set_scp"
 				"2"	"dboi"
 				"3"	"set_blu"

--- a/addons/sourcemod/configs/scp_sf/maps/scp_mandrillmaze.cfg
+++ b/addons/sourcemod/configs/scp_sf/maps/scp_mandrillmaze.cfg
@@ -37,29 +37,7 @@
 			"7"	"set_blu"
 			"8"	"dboi"
 			"9"	"set_blu"
-			"10"	"set_scp"
-			"11"	"dboi"
-			"12"	"set_blu"
-			"13"	"dboi"
-			"14"	"set_blu"
-			"15"	"dboi"
-			"16"	"set_blu"
-			"17"	"dboi"
-			"18"	"set_blu"
-			"19"	"set_scp"
-			"20"	"dboi"
-			"21"	"set_blu"
-			"22"	"dboi"
-			"23"	"set_blu"
-			"24"	"dboi"
-			"25"	"set_blu"
-			"26"	"dboi"
-			"27"	"set_blu"
-			"28"	"dboi"
-			"29"	"set_blu"
-			"30"	"set_scp"
-			"31"	"dboi"
-			"32"	"set_blu"
+			"10"	"set_any"
 		}
 
 		"waves"	// Respawn waves
@@ -71,37 +49,7 @@
 			{
 				"tickets"	"32"
 
-				"1"		"chaos1"
-				"2"		"chaos1"
-				"3"		"chaos1"
-				"4"		"chaos2"
-				"5"		"chaos3"
-				"6"		"chaos1"
-				"7"		"chaos2"
-				"8"		"chaos1"
-				"9"		"chaos2"
-				"10"		"chaos3"
-				"11"		"chaos1"
-				"12"		"chaos1"
-				"13"		"chaos2"
-				"14"		"chaos1"
-				"15"		"chaos3"
-				"16"		"chaos1"
-				"17"		"chaos2"
-				"18"		"chaos1"
-				"19"		"chaos2"
-				"20"		"chaos3"
-				"21"		"chaos1"
-				"22"		"chaos1"
-				"23"		"chaos2"
-				"24"		"chaos1"
-				"25"		"chaos3"
-				"26"		"chaos1"
-				"27"		"chaos2"
-				"28"		"chaos1"
-				"29"		"chaos2"
-				"30"		"chaos3"
-				"31"		"chaos1"
+				"1"		"set_chaos"
 			}
 			"2"
 			{
@@ -114,6 +62,20 @@
 
 		"presets"	// Class sets to pull from
 		{
+			"set_any"
+			{
+				// For every SCP, 8 more humans
+				"type"	"Gamemode_PresentOrder"	// Select in this order, looping
+				"1"	"set_scp"
+				"2"	"dboi"
+				"3"	"set_blu"
+				"4"	"dboi"
+				"5"	"set_blu"
+				"6"	"dboi"
+				"7"	"set_blu"
+				"8"	"dboi"
+				"9"	"set_blu"
+			}
 			"set_blu"
 			{
 				"type"	"Gamemode_PresetRandom"	// Choose randomly
@@ -136,6 +98,14 @@
 				"1"	"mtf1"
 				"2"	"mtf1"
 				"3"	"mtf2"
+			}
+			"set_chaos"
+			{
+				"type"	"Gamemode_PresetRandom"	// Choose randomly
+				"1"	"chaos1"
+				"2"	"chaos1"
+				"3"	"chaos2"
+				"4"	"chaos3"
 			}
 		}
 	}

--- a/addons/sourcemod/configs/scp_sf/maps/szf_.cfg
+++ b/addons/sourcemod/configs/scp_sf/maps/szf_.cfg
@@ -24,7 +24,7 @@
 			"14"	"scp9392"
 		}
 
-		"setup"	// Goes up to 32 players
+		"setup"
 		{
 			"1"	"goc"
 			"2"	"goc"
@@ -33,28 +33,7 @@
 			"5"	"scp610"
 			"6"	"goc"
 			"7"	"goc"
-			"8"	"scp610"
-			"9"	"goc"
-			"10"	"goc"
-			"11"	"goc"
-			"12"	"scp610"
-			"13"	"goc"
-			"14"	"goc"
-			"15"	"goc"
-			"16"	"scp610"
-			"17"	"goc"
-			"18"	"goc"
-			"19"	"goc"
-			"20"	"scp610"
-			"21"	"goc"
-			"22"	"goc"
-			"23"	"goc"
-			"24"	"scp610"
-			"25"	"goc"
-			"26"	"goc"
-			"27"	"goc"
-			"28"	"scp610"
-			"30"	"goc"
+			"8"	"set_any"
 		}
 
 		"waves"	// Respawn waves
@@ -125,6 +104,14 @@
 
 		"presets"	// Class sets to pull from
 		{
+			"set_any"
+			{
+				"type"	"Gamemode_PresentOrder"	// Select in this order, looping
+				"1"	"scp610"
+				"2"	"goc"
+				"3"	"goc"
+				"4"	"goc"
+			}
 			"set_mtf"
 			{
 				"type"	"Gamemode_PresetRandom"	// Choose randomly

--- a/addons/sourcemod/configs/scp_sf/maps/szf_.cfg
+++ b/addons/sourcemod/configs/scp_sf/maps/szf_.cfg
@@ -106,7 +106,7 @@
 		{
 			"set_any"
 			{
-				"type"	"Gamemode_PresentOrder"	// Select in this order, looping
+				"type"	"Gamemode_PresetOrdered"	// Select in this order, looping
 				"1"	"scp610"
 				"2"	"goc"
 				"3"	"goc"

--- a/addons/sourcemod/scripting/scp_sf/gamemode.sp
+++ b/addons/sourcemod/scripting/scp_sf/gamemode.sp
@@ -1533,6 +1533,40 @@ public float Gamemode_WaveRespawnTickets(ArrayList &list, ArrayList &players)
 	return wavetime;
 }
 
+public int Gamemode_PresentOrder(ArrayList list, ArrayList current)
+{
+	static int index;
+	static ArrayList previous;
+	int length = list.Length;
+	int attempts;
+	
+	if (previous != current)
+	{
+		// New array, reset order index
+		index = 0;
+		previous = current;
+	}
+	
+	do
+	{
+		if (index >= length)
+			index = 0;	// Reset back to loop though
+		
+		static char buffer[16];
+		list.GetString(index, buffer, sizeof(buffer));
+		
+		index++;
+		attempts++;
+		
+		int class = PresetToClass(buffer, current);
+		if (class != -1)
+			return class;
+	}
+	while (attempts < length);
+	
+	return -1;
+}
+
 public int Gamemode_PresetRandom(ArrayList list, ArrayList current)
 {
 	static char buffer[16];

--- a/addons/sourcemod/scripting/scp_sf/gamemode.sp
+++ b/addons/sourcemod/scripting/scp_sf/gamemode.sp
@@ -1533,7 +1533,7 @@ public float Gamemode_WaveRespawnTickets(ArrayList &list, ArrayList &players)
 	return wavetime;
 }
 
-public int Gamemode_PresentOrder(ArrayList list, ArrayList current)
+public int Gamemode_PresetOrdered(ArrayList list, ArrayList current)
 {
 	static int index;
 	static ArrayList previous;
@@ -1550,7 +1550,7 @@ public int Gamemode_PresentOrder(ArrayList list, ArrayList current)
 	do
 	{
 		if (index >= length)
-			index = 0;	// Reset back to loop though
+			index = 0;	// Reset back to loop it
 		
 		static char buffer[16];
 		list.GetString(index, buffer, sizeof(buffer));


### PR DESCRIPTION
Currently when there are not enough classes from the list to set all players, it reuses the last class in the list to set the rest of it.

This update makes use of that by using `Gamemode_PresentOrder` that goes into a loop on which class to select at the end of the list. `set_any` would set an SCP for every 8 humans, thus allowing more than 4 SCPs alive with >32 players.

The only noticeable gameplay change this should give with <=32 players is the max SCP count will always be 4, rather than just 3 or 4 by random. I think we can allow that to give SCP a better chance to win.

Only szf_turtle_support is untouched from this, i'll let @Alex-Turtle decide how the class list should look like.