### PR TITLE
Add convar to limit max dropped weapons in map

### DIFF
--- a/addons/sourcemod/scripting/scp_sf.sp
+++ b/addons/sourcemod/scripting/scp_sf.sp
@@ -111,6 +111,7 @@ ConVar CvarKarmaRatio;
 ConVar CvarKarmaMin;
 ConVar CvarKarmaMax;
 ConVar CvarAllowCosmetics;
+ConVar CvarDroppedWeaponCount;
 float NextHintAt = FAR_FUTURE;
 float RoundStartAt;
 float EndRoundIn;

--- a/addons/sourcemod/scripting/scp_sf/convars.sp
+++ b/addons/sourcemod/scripting/scp_sf/convars.sp
@@ -27,7 +27,7 @@ void ConVar_Setup()
 	CvarKarmaMin = CreateConVar("scp_karmamin", "0.0", "Minimum karma level", _, true, 0.0, true, 100.0);
 	CvarKarmaMax = CreateConVar("scp_karmamax", "100.0", "Maximum karma level", _, true, 0.0, true, 100.0);
 	CvarAllowCosmetics = CreateConVar("scp_allowcosmetics", "1", "Whether to allow certain classes to equip cosmetics", _, true, 0.0, true, 1.0);
-	CvarDroppedWeaponCount = CreateConVar("scp_droppedweaponcount", "100", "How many dropped weapon to allow in map, -1 for no limit", _, true, -1.0);
+	CvarDroppedWeaponCount = CreateConVar("scp_droppedweaponcount", "-1", "How many dropped weapon to allow in map, -1 for no limit", _, true, -1.0);
 	
 	AutoExecConfig(true, "SCPSecretFortress");
 

--- a/addons/sourcemod/scripting/scp_sf/convars.sp
+++ b/addons/sourcemod/scripting/scp_sf/convars.sp
@@ -27,6 +27,7 @@ void ConVar_Setup()
 	CvarKarmaMin = CreateConVar("scp_karmamin", "0.0", "Minimum karma level", _, true, 0.0, true, 100.0);
 	CvarKarmaMax = CreateConVar("scp_karmamax", "100.0", "Maximum karma level", _, true, 0.0, true, 100.0);
 	CvarAllowCosmetics = CreateConVar("scp_allowcosmetics", "1", "Whether to allow certain classes to equip cosmetics", _, true, 0.0, true, 1.0);
+	CvarDroppedWeaponCount = CreateConVar("scp_droppedweaponcount", "100", "How many dropped weapon to allow in map, -1 for no limit", _, true, -1.0);
 	
 	AutoExecConfig(true, "SCPSecretFortress");
 

--- a/addons/sourcemod/scripting/scp_sf/items.sp
+++ b/addons/sourcemod/scripting/scp_sf/items.sp
@@ -911,6 +911,33 @@ bool Items_DropItem(int client, int helditem, const float origin[3], const float
 
 			TeleportEntity(entity, origin, NULL_VECTOR, vel);
 			result = true;
+			
+			// Add dropped weapon to list, ordered by time created
+			static ArrayList droppedweapons;
+			if (!droppedweapons)
+				droppedweapons = new ArrayList();
+			
+			droppedweapons.Push(EntIndexToEntRef(entity));
+			int length = droppedweapons.Length;
+			for (int i = length - 1; i >= 0; i--)
+			{
+				// Clean up any ents that were already removed
+				if (!IsValidEntity(droppedweapons.Get(i)))
+					droppedweapons.Erase(i);
+			}
+			
+			int maxcount = CvarDroppedWeaponCount.IntValue;
+			if (maxcount != -1)
+			{
+				// If there are too many dropped weapon, remove some ordered by time created
+				length = droppedweapons.Length;
+				while (length > maxcount)
+				{
+					RemoveEntity(droppedweapons.Get(0));
+					droppedweapons.Erase(0);
+					length--;
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Lots of weapons can be dropped in high playercount, so lets add a convar `scp_droppedweaponcount` which would limit how many dropped weapons to allow in map. Deletes any old dropped weapons if reached the limit.

Not certain what the good default value should be, 100 might be enough for a 32 player server.