### PR TITLE
Revolver, Armor rebalancing and SCP-939 speed on HP lost buff

### DIFF
--- a/addons/sourcemod/configs/scp_sf/weapons.cfg
+++ b/addons/sourcemod/configs/scp_sf/weapons.cfg
@@ -289,7 +289,7 @@
 	"61"	// Revolver
 	{
 		"classname"	"tf_weapon_revolver"
-		"attributes"	"2 ; 1.5 ; 5 ; 0.8 ; 96 ; 0.2 ; 106 ; 0.5 ; 389 ; 3"
+		"attributes"	"2 ; 1.5 ; 5 ; 0.8 ; 96 ; 0.2 ; 106 ; 0.25 ; 389 ; 3"
 		"strip"		"1"
 		"type"		"1"
 		"clip"		"6"

--- a/addons/sourcemod/configs/scp_sf/weapons.cfg
+++ b/addons/sourcemod/configs/scp_sf/weapons.cfg
@@ -289,7 +289,7 @@
 	"61"	// Revolver
 	{
 		"classname"	"tf_weapon_revolver"
-		"attributes"	"2 ; 1.6 ; 5 ; 0.2 ; 96 ; 0.2 ; 106 ; 0.25 ; 389 ; 3"
+		"attributes"	"2 ; 1.5 ; 5 ; 0.8 ; 96 ; 0.2 ; 106 ; 0.5 ; 389 ; 3"
 		"strip"		"1"
 		"type"		"1"
 		"clip"		"6"

--- a/addons/sourcemod/configs/scp_sf/weapons.cfg
+++ b/addons/sourcemod/configs/scp_sf/weapons.cfg
@@ -289,7 +289,7 @@
 	"61"	// Revolver
 	{
 		"classname"	"tf_weapon_revolver"
-		"attributes"	"2 ; 1.5 ; 5 ; 0.8 ; 96 ; 0.2 ; 106 ; 0.25 ; 389 ; 3"
+		"attributes"	"2 ; 1.5 ; 5 ; 1.25 ; 96 ; 1.25 ; 106 ; 0.25 ; 389 ; 3"
 		"strip"		"1"
 		"type"		"1"
 		"clip"		"6"
@@ -912,7 +912,7 @@
 	"30019"	// Light Armor
 	{
 		"classname"	"tf_weapon_fists"
-		"attributes"	"62 ; 0.8 ; 64 ; 0.95 ; 66 ; 0.8 ; 252 ; 0.8 "
+		"attributes"	"54; 0.8 ; 62 ; 0.8 ; 64 ; 0.95 ; 66 ; 0.8 ; 252 ; 0.8 "
 		"type"		"6"
 		"hide"		"1"
 
@@ -928,7 +928,7 @@
 	"30020"	// Combat Armor
 	{
 		"classname"	"tf_weapon_fists"
-		"attributes"	"54 ; 0.95 ; 62 ; 0.9 ; 64 ; 0.7 ; 66 ; 0.7 ; 252 ; 0.5 "
+		"attributes"	"54 ; 0.75 ; 62 ; 0.95 ; 64 ; 0.7 ; 66 ; 0.7 ; 252 ; 0.5 "
 		"type"		"6"
 		"hide"		"1"
 
@@ -945,7 +945,7 @@
 	"30021"	// Heavy Armor
 	{
 		"classname"	"tf_weapon_fists"
-		"attributes"	"54 ; 0.85 ; 62 ; 0.85 ; 64 ; 0.6 ; 66 ; 0.6 ; 252 ; 0.2 "
+		"attributes"	"54 ; 0.7 ; 62 ; 0.9 ; 64 ; 0.6 ; 66 ; 0.6 ; 252 ; 0.2 "
 		"type"		"6"
 		"hide"		"1"
 

--- a/addons/sourcemod/configs/scp_sf/weapons.cfg
+++ b/addons/sourcemod/configs/scp_sf/weapons.cfg
@@ -289,7 +289,7 @@
 	"61"	// Revolver
 	{
 		"classname"	"tf_weapon_revolver"
-		"attributes"	"1 ; 0.760417 ; 6 ; 0.85 ; 43 ; 1 ; 96 ; 1.666667 ; 106 ; 0.25 ; 199 ; 0.9 ; 389 ; 3 ; 4363 ; 0.5"
+		"attributes"	"2 ; 1.6 ; 5 ; 0.2 ; 96 ; 0.2 ; 106 ; 0.25 ; 389 ; 3"
 		"strip"		"1"
 		"type"		"1"
 		"clip"		"6"
@@ -297,7 +297,7 @@
 		"bullet"	"10"
 		"class"		"spy"
 
-		"model"		"models/weapons/c_models/c_ambassador/c_ambassador.mdl"
+		"model"		"models/weapons/c_models/c_revolver/c_revolver.mdl"
 
 		"func_damage"	"Items_HeadshotHit"
 		"func_button"    "Items_DisarmerButton"
@@ -912,7 +912,7 @@
 	"30019"	// Light Armor
 	{
 		"classname"	"tf_weapon_fists"
-		"attributes"	"62 ; 0.82 ; 64 ; 0.84 ; 66 ; 0.84 ; 252 ; 0.8 ; 476 ; 0"
+		"attributes"	"62 ; 0.8 ; 64 ; 0.95 ; 66 ; 0.8 ; 252 ; 0.8 "
 		"type"		"6"
 		"hide"		"1"
 
@@ -928,7 +928,7 @@
 	"30020"	// Combat Armor
 	{
 		"classname"	"tf_weapon_fists"
-		"attributes"	"62 ; 0.68 ; 64 ; 0.74 ; 66 ; 0.74 ; 252 ; 0.6 ; 476 ; 0"
+		"attributes"	"54 ; 0.95 ; 62 ; 0.9 ; 64 ; 0.7 ; 66 ; 0.7 ; 252 ; 0.5 "
 		"type"		"6"
 		"hide"		"1"
 
@@ -945,7 +945,7 @@
 	"30021"	// Heavy Armor
 	{
 		"classname"	"tf_weapon_fists"
-		"attributes"	"62 ; 0.68 ; 64 ; 0.68 ; 66 ; 0.68 ; 252 ; 0.4 ; 476 ; 0"
+		"attributes"	"54 ; 0.85 ; 62 ; 0.85 ; 64 ; 0.6 ; 66 ; 0.6 ; 252 ; 0.2 "
 		"type"		"6"
 		"hide"		"1"
 

--- a/addons/sourcemod/scripting/scp_sf/scps/939.sp
+++ b/addons/sourcemod/scripting/scp_sf/scps/939.sp
@@ -66,7 +66,7 @@ public void SCP939_OnMaxHealth(int client, int &health)
 
 public void SCP939_OnSpeed(int client, float &speed)
 {
-	speed += Pow((1.0-(Health[client]/HealthMax)), 2)*SpeedExtra;
+	speed += Pow((1.0-(Health[client]/HealthMax)), 2.0)*SpeedExtra;
 }
 
 public Action SCP939_OnDealDamage(int client, int victim, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)

--- a/addons/sourcemod/scripting/scp_sf/scps/939.sp
+++ b/addons/sourcemod/scripting/scp_sf/scps/939.sp
@@ -4,7 +4,7 @@
 static const int HealthMax = 1800;	// Max standard health
 static const int HealthExtra = 600;	// Max regenerable health
 
-static const float SpeedExtra = 50.0;	// Extra speed while low health
+static const float SpeedExtra = 80.0;	// Extra speed while low health
 static const float GlowRange = 800.0;	// Max outline range
 
 static int Health[MAXPLAYERS + 1];
@@ -66,7 +66,7 @@ public void SCP939_OnMaxHealth(int client, int &health)
 
 public void SCP939_OnSpeed(int client, float &speed)
 {
-	speed += (1.0-(Health[client]/HealthMax))*SpeedExtra;
+	speed += Pow((1.0-(Health[client]/HealthMax)), 2)*SpeedExtra;
 }
 
 public Action SCP939_OnDealDamage(int client, int victim, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)

--- a/addons/sourcemod/scripting/scp_sf/scps/939.sp
+++ b/addons/sourcemod/scripting/scp_sf/scps/939.sp
@@ -66,7 +66,7 @@ public void SCP939_OnMaxHealth(int client, int &health)
 
 public void SCP939_OnSpeed(int client, float &speed)
 {
-	speed += (1.0-(Pow(Health[client]/HealthMax), 2.0))*SpeedExtra;
+	speed += (1.0-(Pow((Health[client]/HealthMax), 2.0)))*SpeedExtra;
 }
 
 public Action SCP939_OnDealDamage(int client, int victim, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)

--- a/addons/sourcemod/scripting/scp_sf/scps/939.sp
+++ b/addons/sourcemod/scripting/scp_sf/scps/939.sp
@@ -4,7 +4,7 @@
 static const int HealthMax = 1800;	// Max standard health
 static const int HealthExtra = 600;	// Max regenerable health
 
-static const float SpeedExtra = 80.0;	// Extra speed while low health
+static const float SpeedExtra = 70.0;	// Extra speed while low health
 static const float GlowRange = 800.0;	// Max outline range
 
 static int Health[MAXPLAYERS + 1];
@@ -66,7 +66,7 @@ public void SCP939_OnMaxHealth(int client, int &health)
 
 public void SCP939_OnSpeed(int client, float &speed)
 {
-	speed += Pow((1.0-(Health[client]/HealthMax)), 2.0)*SpeedExtra;
+	speed += (1.0-(Pow(Health[client]/HealthMax), 2.0))*SpeedExtra;
 }
 
 public Action SCP939_OnDealDamage(int client, int victim, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)

--- a/addons/sourcemod/scripting/scp_sf/scps/939.sp
+++ b/addons/sourcemod/scripting/scp_sf/scps/939.sp
@@ -66,7 +66,7 @@ public void SCP939_OnMaxHealth(int client, int &health)
 
 public void SCP939_OnSpeed(int client, float &speed)
 {
-	speed += (1.0-(Pow((Health[client]/HealthMax), 2.0)))*SpeedExtra;
+	speed += (1.0-(Pow(float(Health[client])/float(HealthMax), 2.0)))*SpeedExtra;
 }
 
 public Action SCP939_OnDealDamage(int client, int victim, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)


### PR DESCRIPTION
Revolver has had its model changed, damage increased and reload speed with fire rate reduced.
Armor received higher resistance values, but Combat and Heavy armor now have a minor base move speed penalty.
SCP-939 had its speed buff passive cap increased and the buff has been made more potent on higher HP values.