### PR TITLE
Don't reveal name on who you're disarming

### DIFF
--- a/addons/sourcemod/scripting/scp_sf/items.sp
+++ b/addons/sourcemod/scripting/scp_sf/items.sp
@@ -2559,15 +2559,18 @@ public bool Items_DisarmerButton(int client, int weapon, int &buttons, int &hold
 		delay[client] = engineTime + 0.1;
 		DisarmerCharge[client] += 10.0;
 		
+		ClassEnum class;
+		Classes_GetByIndex(Client[target].Class, class);
+		
 		SetHudTextParamsEx(-1.0, 0.6, 0.35, Client[client].Colors, Client[client].Colors, 0, 1.0, 0.01, 0.5);
 		if(canDisarm)
 		{
-			ShowSyncHudText(client, HudPlayer, "%t", "disarming_other", target, DisarmerCharge[client]);
+			ShowSyncHudText(client, HudPlayer, "%t", "disarming_other", class.Display, DisarmerCharge[client]);
 			ShowSyncHudText(target, HudPlayer, "%t", "disarming_me", client, DisarmerCharge[client]);
 		}
 		else if (canUndisarm)
 		{
-			ShowSyncHudText(client, HudPlayer, "%t", "arming_other", target, DisarmerCharge[client]);
+			ShowSyncHudText(client, HudPlayer, "%t", "arming_other", class.Display, DisarmerCharge[client]);
 			ShowSyncHudText(target, HudPlayer, "%t", "arming_me", client, DisarmerCharge[client]);
 		}
 	
@@ -2595,8 +2598,7 @@ public bool Items_DisarmerButton(int client, int weapon, int &buttons, int &hold
 				}
 				Items_SetEmptyWeapon(target);
 				
-				ClassEnum class;
-				if(Classes_GetByIndex(Client[target].Class, class) && class.Group==2 && !class.Vip)
+				if(class.Group==2 && !class.Vip)
 					GiveAchievement(Achievement_DisarmMTF, client);
 				
 				// all weapons are gone, so reset the time		

--- a/addons/sourcemod/translations/chi/scp_sf.phrases.txt
+++ b/addons/sourcemod/translations/chi/scp_sf.phrases.txt
@@ -1274,7 +1274,7 @@
 	}
 	"disarming_other"    // HUD
     {
-        "#format"    "{1:N},{2:.0f}"
+        "#format"    "{1:t},{2:.0f}"
         "chi"        "解除武装 {1}... {2}%"
     }
 	"disarming_me"    // HUD
@@ -1284,7 +1284,7 @@
     }
 	"arming_other" // HUD
     {
-        "#format"    "{1:N},{2:.0f}"
+        "#format"    "{1:t},{2:.0f}"
         "chi"        "解开手铐 {1}... {2}%"
     }
     "arming_me" // HUD

--- a/addons/sourcemod/translations/es/scp_sf.phrases.txt
+++ b/addons/sourcemod/translations/es/scp_sf.phrases.txt
@@ -1286,7 +1286,7 @@
 	}
 	"disarming_other"    // HUD
     {
-        "#format"    "{1:N},{2:.0f}"
+        "#format"    "{1:t},{2:.0f}"
         "es"        "Desarmando {1}... {2}%"
     }
 	"disarming_me"    // HUD
@@ -1296,7 +1296,7 @@
     }
     "arming_other" // HUD
     {
-        "#format"    "{1:N},{2:.0f}"
+        "#format"    "{1:t},{2:.0f}"
         "es"        "Desnudo {1}... {2}%"
     }
 	"arming_me" // HUD

--- a/addons/sourcemod/translations/it/scp_sf.phrases.txt
+++ b/addons/sourcemod/translations/it/scp_sf.phrases.txt
@@ -1291,7 +1291,7 @@
 	}
 	"disarming_other"    // HUD
     {
-        "#format"    "{1:N},{2:.0f}"
+        "#format"    "{1:t},{2:.0f}"
         "it"        "Disarmo {1}... {2}%"
     }
 	"disarming_me"    // HUD
@@ -1301,7 +1301,7 @@
     }
     "arming_other" // HUD
     {
-        "#format"    "{1:N},{2:.0f}"
+        "#format"    "{1:t},{2:.0f}"
         "it"        "Smaltire il tappo {1}... {2}%"
     }
 	"arming_me" // HUD

--- a/addons/sourcemod/translations/scp_sf.phrases.txt
+++ b/addons/sourcemod/translations/scp_sf.phrases.txt
@@ -1291,7 +1291,7 @@
 	}
     "disarming_other"    // HUD
     {
-        "#format"    "{1:N},{2:.0f}"
+        "#format"    "{1:t},{2:.0f}"
         "en"        "Disarming {1}... {2}%"
     }
 	"disarming_me"    // HUD
@@ -1301,7 +1301,7 @@
     }
     "arming_other" // HUD
     {
-        "#format"    "{1:N},{2:.0f}"
+        "#format"    "{1:t},{2:.0f}"
         "en"        "Uncuffing {1}... {2}%"
     }
 	"arming_me" // HUD


### PR DESCRIPTION
Instead of showing by user name `Disarming Luksus322... 69%`, it shows by class type `Disarming Class-D Personnel... 69%`.

Could also update display on whos disarming to you, e.g. `Luksus322 is disarming you... 69%`, but neutral on whenever to do it.