### PR TITLE
Fix error from doors during plugin start

### DIFF
--- a/addons/sourcemod/scripting/scp_sf.sp
+++ b/addons/sourcemod/scripting/scp_sf.sp
@@ -262,6 +262,7 @@ public void OnPluginStart()
 
 	ConVar_Setup();
 	SDKHook_Setup();
+	Doors_Clear();
 
 	HookEvent("teamplay_round_start", OnRoundStart, EventHookMode_PostNoCopy);
 	HookEvent("teamplay_round_win", OnRoundEnd, EventHookMode_PostNoCopy);
@@ -568,7 +569,7 @@ public void OnRoundStart(Event event, const char[] name, bool dontBroadcast)
 		}
 	}
 
-	Doors_RoundStart();
+	Doors_Clear();
 	Items_RoundStart();
 	// see comments in szf.sp for why this is here
 	SZF_RoundStartDelayed();

--- a/addons/sourcemod/scripting/scp_sf/doors.sp
+++ b/addons/sourcemod/scripting/scp_sf/doors.sp
@@ -5,7 +5,7 @@ StringMap DoorNameToActivator;
 // this is needed for frag grenade/scp18/096 door destruction logic
 // however, maps use scp_access relays for checks, which we will abuse to find what is a "checkpoint" door
 
-void Doors_RoundStart()
+void Doors_Clear()
 {
 	delete DoorNameToActivator;
 	DoorNameToActivator = new StringMap();


### PR DESCRIPTION
It was only setup during round start, not taking into account after plugin load and before round start.