### PR TITLE
Remove hidden attribute melee_cleave_attack

### DIFF
--- a/addons/sourcemod/scripting/scp_sf/scps/096.sp
+++ b/addons/sourcemod/scripting/scp_sf/scps/096.sp
@@ -152,7 +152,7 @@ public void SCP096_OnButton(int client, int button)
 				TF2_AddCondition(client, TFCond_CritCola, 99.9);
 
 				TF2_RemoveWeaponSlot(client, TFWeaponSlot_Melee);
-				int weapon = SpawnWeapon(client, "tf_weapon_sword", 310, 100, 13, "2 ; 11 ; 6 ; 0.95 ; 28 ; 3 ; 252 ; 0 ; 326 ; 2 ; 412 ; 0.6 ; 4328 ; 1", false);
+				int weapon = SpawnWeapon(client, "tf_weapon_sword", 310, 100, 13, "2 ; 11 ; 6 ; 0.95 ; 28 ; 3 ; 252 ; 0 ; 326 ; 2 ; 412 ; 0.6", false);
 				if(weapon > MaxClients)
 				{
 					ApplyStrangeRank(weapon, 16);

--- a/addons/sourcemod/scripting/scp_sf/scps/939.sp
+++ b/addons/sourcemod/scripting/scp_sf/scps/939.sp
@@ -17,7 +17,7 @@ public bool SCP939_Create(int client)
 	
 	int account = GetSteamAccountID(client, false);
 
-	int weapon = SpawnWeapon(client, "tf_weapon_knife", 461, 70, 13, "2 ; 1.625 ; 15 ; 0 ; 252 ; 0.3 ; 412 ; 0.8 ; 4328 ; 1", false);
+	int weapon = SpawnWeapon(client, "tf_weapon_knife", 461, 70, 13, "2 ; 1.625 ; 15 ; 0 ; 252 ; 0.3 ; 412 ; 0.8", false);
 	if(weapon > MaxClients)
 	{
 		ApplyStrangeRank(weapon, 10);

--- a/addons/sourcemod/scripting/scp_sf/scps/sjm08.sp
+++ b/addons/sourcemod/scripting/scp_sf/scps/sjm08.sp
@@ -37,7 +37,7 @@ void SJM08_Clean()	// OnRoundEnd, OnPluginEnd
 
 public bool SJM08_Create(int client)
 {
-	int weapon = SpawnWeapon(client, "tf_weapon_club", 880, 8, 14, "1 ; 0.615385 ; 5 ; 3 ; 28 ; 0.5 ; 206 ; 0.1 ; 252 ; 0 ; 4328 ; 1", false);
+	int weapon = SpawnWeapon(client, "tf_weapon_club", 880, 8, 14, "1 ; 0.615385 ; 5 ; 3 ; 28 ; 0.5 ; 206 ; 0.1 ; 252 ; 0", false);
 	if(weapon > MaxClients)
 	{
 		ApplyStrangeRank(weapon, 8);


### PR DESCRIPTION
From #134, leftover attribute from when SCP used to require hidden attributes plugin