### PR TITLE
Fix PassServerEntityFilter detour for linux

### DIFF
--- a/addons/sourcemod/gamedata/scp_sf.txt
+++ b/addons/sourcemod/gamedata/scp_sf.txt
@@ -119,7 +119,7 @@
 			"PassServerEntityFilter"
 			{
 				"library"	"server"
-				"linux"		"@_Z22PassServerEntityFilterPK13IHandleEntityS1_"
+				"linux"		"@_Z22PassServerEntityFilterPK13IHandleEntityS1_.part.0"
 				"windows"	"\x55\x8B\xEC\x56\x8B\x75\x0C\x57\x85\xF6\x74\x2A\x8B\x7D\x08"
 			}
 		}
@@ -381,10 +381,18 @@
 					"touch"
 					{
 						"type" "cbaseentity"
+						"linux"
+						{
+							"register"	"eax"
+						}
 					}
 					"pass"
 					{
 						"type" "cbaseentity"
+						"linux"
+						{
+							"register"	"edx"
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Fixes #137

x64 update made this update have a clone version of it, needing to use that function to detour it.
Thanks to @Kenzzer and @nosoop for the help into this issue.