### PR TITLE
Fix case of SCP win when only captured has escaped

### DIFF
--- a/addons/sourcemod/scripting/scp_sf/gamemode.sp
+++ b/addons/sourcemod/scripting/scp_sf/gamemode.sp
@@ -1140,7 +1140,7 @@ public bool Gamemode_ConditionVip(TFTeam &team)
 		team = TFTeam_Blue;
 		group = 2;
 	}
-	else if(salive && !sescape)	// SCP alive and none escaped
+	else if(salive && !sescape && !scapture)	// SCP alive and none escaped/captured
 	{
 		team = TFTeam_Red;
 		group = 3;


### PR DESCRIPTION
SCP win can be incorrectly given if only captured has escaped and it's tied. Doesn't make sense when a win is given when only one has escaped, and alt version of the win already checks for captured escapes.