### PR TITLE
Store class names in lowercase

### DIFF
--- a/addons/sourcemod/scripting/scp_sf/classes.sp
+++ b/addons/sourcemod/scripting/scp_sf/classes.sp
@@ -127,6 +127,7 @@ void Classes_Setup(KeyValues main, KeyValues map, ArrayList whitelist)
 			if(!kv.GetSectionName(class.Name, sizeof(class.Name)) || StrEqual(class.Name, "default"))
 				continue;
 
+			StrToLower(class.Name);
 			if(whitelist && whitelist.FindString(class.Name)==-1)
 				continue;
 

--- a/addons/sourcemod/scripting/scp_sf/classes.sp
+++ b/addons/sourcemod/scripting/scp_sf/classes.sp
@@ -124,7 +124,7 @@ void Classes_Setup(KeyValues main, KeyValues map, ArrayList whitelist)
 		int count;
 		do
 		{
-			if(!kv.GetSectionName(class.Name, sizeof(class.Name)) || StrEqual(class.Name, "default"))
+			if(!kv.GetSectionName(class.Name, sizeof(class.Name)) || StrEqual(class.Name, "default", false))
 				continue;
 
 			StrToLower(class.Name);

--- a/addons/sourcemod/scripting/scp_sf/gamemode.sp
+++ b/addons/sourcemod/scripting/scp_sf/gamemode.sp
@@ -877,7 +877,10 @@ static ArrayList GrabClassList(KeyValues kv)
 	{
 		IntToString(i, buffer, sizeof(buffer));
 		kv.GetString(buffer, buffer, sizeof(buffer));
-		if(!buffer[0])
+
+		if(buffer[0])	// Convert the string to lowercase because keyvalues might uppercase them
+			StrToLower(buffer);
+		else
 			break;
 
 		list.PushString(buffer);

--- a/addons/sourcemod/scripting/scp_sf/stocks.sp
+++ b/addons/sourcemod/scripting/scp_sf/stocks.sp
@@ -1615,3 +1615,10 @@ stock int CreateExplosion(int attacker = -1, int damage = 0, int radius = -1, fl
 	
 	return explosion;
 }
+
+stock void StrToLower(char[] sBuffer)
+{
+	int iLength = strlen(sBuffer);
+	for (int i = 0; i < iLength; i++)
+		sBuffer[i] = CharToLower(sBuffer[i]);
+}

--- a/addons/sourcemod/scripting/scp_sf/stocks.sp
+++ b/addons/sourcemod/scripting/scp_sf/stocks.sp
@@ -1616,9 +1616,9 @@ stock int CreateExplosion(int attacker = -1, int damage = 0, int radius = -1, fl
 	return explosion;
 }
 
-stock void StrToLower(char[] sBuffer)
+stock void StrToLower(char[] buffer)
 {
-	int iLength = strlen(sBuffer);
-	for (int i = 0; i < iLength; i++)
-		sBuffer[i] = CharToLower(sBuffer[i]);
+	int length = strlen(buffer);
+	for (int i = 0; i < length; i++)
+		buffer[i] = CharToLower(buffer[i]);
 }


### PR DESCRIPTION
Ensures there's no case mismatch when looking for class names, prevents potentially skipping some.