### PR TITLE
Replace PassServerEntityFilter detour to ShouldHitEntity

### DIFF
--- a/addons/sourcemod/gamedata/scp_sf.txt
+++ b/addons/sourcemod/gamedata/scp_sf.txt
@@ -106,6 +106,12 @@
 				"linux"		"@_ZN14CWeaponMedigun19AllowedToHealTargetEP11CBaseEntity"
 				"windows"	"\x55\x8B\xEC\x53\x8B\xD9\x56\x57\x8B\x93\x10\x02\x00\x00\x85\xD2\x0F\x84\x2A\x2A\x2A\x2A\xB9\xFF\x1F\x00\x00\x83\xFA\xFF\x74\x2A\x0F\xB7\xCA\xA1\x2A\x2A\x2A\x2A\xC1\xE1\x04\x8D\x78\x04\x03\xF9\x0F\x84\x2A\x2A\x2A\x2A\xC1\xEA\x10\x39\x57\x04\x0F\x85\x2A\x2A\x2A\x2A\x8B\x3F\x85\xFF\x0F\x84\x2A\x2A\x2A\x2A\x8B\x07\x8B\xCF\x8B\x80\x48\x01\x00\x00\xFF\xD0\x84\xC0\x0F\x84\x2A\x2A\x2A\x2A\x8B\x75\x08\x85\xF6\x74\x2A"
 			}
+			"CTraceFilterSimple::ShouldHitEntity"
+			{
+				"library"	"server"
+				"linux"		"@_ZN18CTraceFilterSimple15ShouldHitEntityEP13IHandleEntityi"
+				"windows"	"\x55\x8B\xEC\x57\xFF\x75\x0C\x8B\xF9\xFF\x75\x08\xE8\x2A\x2A\x2A\x2A\x83\xC4\x08"
+			}
 			"AI_CriteriaSet::FindCriterionIndex"
 			{
 				"linux"		"@_ZNK14AI_CriteriaSet18FindCriterionIndexEPKc"
@@ -115,12 +121,6 @@
 			{
 				"linux"		"@_ZN14AI_CriteriaSet14RemoveCriteriaEPKc"
 				"windows"	"\x55\x8B\xEC\x83\xEC\x48\x56\x57\xFF\x75\x08"
-			}
-			"PassServerEntityFilter"
-			{
-				"library"	"server"
-				"linux"		"@_Z22PassServerEntityFilterPK13IHandleEntityS1_.part.0"
-				"windows"	"\x55\x8B\xEC\x56\x8B\x75\x0C\x57\x85\xF6\x74\x2A\x8B\x7D\x08"
 			}
 		}
 		"Functions"
@@ -356,6 +356,38 @@
 					}
 				}
 			}
+			"CWeaponMedigun::AllowedToHealTarget"
+			{
+				"signature"	"CWeaponMedigun::AllowedToHealTarget"
+				"callconv"	"thiscall"
+				"return"	"bool"
+				"this"		"entity"
+				"arguments"
+				{
+					"target"
+					{
+						"type"	"cbaseentity"
+					}
+				}
+			}
+			"CTraceFilterSimple::ShouldHitEntity"
+			{
+				"signature" "CTraceFilterSimple::ShouldHitEntity"
+				"callconv" "thiscall"
+				"return" 	"bool"
+				"this"		"address"
+				"arguments"
+				{
+					"pHandleEntity"
+					{
+						"type" "cbaseentity"
+					}
+					"contentsMask"
+					{
+						"type" "int"
+					}
+				}
+			}
 			"CBaseEntity::ModifyOrAppendCriteria"
 			{
 				"offset"	"CBaseEntity::ModifyOrAppendCriteria"
@@ -367,32 +399,6 @@
 					"criteriaSet"
 					{
 						"type"	"int"
-					}
-				}
-			}
-			"PassServerEntityFilter"
-			{
-				// bool PassServerEntityFilter( const IHandleEntity *pTouch, const IHandleEntity *pPass )
-				"signature" "PassServerEntityFilter"
-				"callconv" "cdecl"
-				"return" "bool"
-				"arguments"
-				{
-					"touch"
-					{
-						"type" "cbaseentity"
-						"linux"
-						{
-							"register"	"eax"
-						}
-					}
-					"pass"
-					{
-						"type" "cbaseentity"
-						"linux"
-						{
-							"register"	"edx"
-						}
 					}
 				}
 			}

--- a/addons/sourcemod/scripting/scp_sf/stocks.sp
+++ b/addons/sourcemod/scripting/scp_sf/stocks.sp
@@ -1454,6 +1454,22 @@ bool IsPointTouchingBox(float pos[3], float mins[3], float maxs[3])
 	return true;
 }
 
+int GetEntityFromHandle(any handle)
+{
+	int ent = handle & 0xFFF;
+	if (ent == 0xFFF)
+		ent = -1;
+	return ent;
+}
+
+int GetEntityFromAddress(Address entity)
+{
+	if (entity == Address_Null)
+		return -1;
+
+	return GetEntityFromHandle(LoadFromAddress(entity + view_as<Address>(FindDataMapInfo(0, "m_angRotation") + 12), NumberType_Int32));
+}
+
 int StringtToCharArray(Address stringt, char[] buffer, int maxlen)
 {
 	if (stringt == Address_Null)


### PR DESCRIPTION
detouring `PassServerEntityFilter` is messed up when needing to set specific register, and then SM safetyhook just breaks the whole thing. Replace it with `CTraceFilterSimple::ShouldHitEntity`.

Also updated `CWeaponMedigun::AllowedToHealTarget` to use gamedata config while at it.