### PR TITLE
Add OnUpdateListenOverrides Forward

### DIFF
--- a/addons/sourcemod/scripting/include/scp_sf.inc
+++ b/addons/sourcemod/scripting/include/scp_sf.inc
@@ -211,6 +211,21 @@ forward void SCPSF_OnWeapon(int client, int entity);
  */
 forward Action SCPSF_OnReactionPre(int client, const char[] event, char sound[PLATFORM_MAX_PATH]);
 
+/**
+ * Calls when listen overrides are being checked between two clients
+ *
+ * @note			Does not go through if the listener has the talker muted client-side
+ *
+ * @param listener 	Client index of the listener
+ * @param talker 	Client index of the talker
+ *
+ * @return		Plugin_Continue - No changes
+ *			Plugin_Changed - Stops the listener from hearing the talker
+ *			Plugin_Handled - Stops the listener from hearing the talker
+ *			Plugin_Stop - Stops the listener from hearing the talker
+ */
+forward Action SCPSF_OnUpdateListenOverrides(int listener, int talker);
+
 public SharedPlugin __pl_SCPSF =
 {
 	name = "scp_sf",

--- a/addons/sourcemod/scripting/scp_sf.sp
+++ b/addons/sourcemod/scripting/scp_sf.sp
@@ -2610,11 +2610,17 @@ public void UpdateListenOverrides(float engineTime)
 					continue;
 				}
 
-				Client[target].CanTalkTo[client] = true;
+				if (Forward_OnUpdateListenOverrides(client, target) != Plugin_Continue)
+				{
+					Client[target].CanTalkTo[client] = false;
+					SetListenOverride(client, target, Listen_No);
+					continue;
+				}
 
 				#if defined _sourcecomms_included
 				if(SourceComms && SourceComms_GetClientMuteType(target)>bNot)
 				{
+					Client[target].CanTalkTo[client] = false;
 					SetListenOverride(client, target, Listen_No);
 					continue;
 				}
@@ -2623,11 +2629,13 @@ public void UpdateListenOverrides(float engineTime)
 				#if defined _basecomm_included
 				if(BaseComm && BaseComm_IsClientMuted(target))
 				{
+					Client[target].CanTalkTo[client] = false;
 					SetListenOverride(client, target, Listen_No);
 					continue;
 				}
 				#endif
 
+				Client[target].CanTalkTo[client] = true;
 				SetListenOverride(client, target, Listen_Default);
 			}
 		}
@@ -2670,6 +2678,9 @@ public void UpdateListenOverrides(float engineTime)
 
 			bool muted = (manage && IsClientMuted(client[i], client[a]));
 			bool blocked = muted;
+
+			if(!blocked && Forward_OnUpdateListenOverrides(client[i], client[a]) != Plugin_Continue)
+				blocked = true;
 
 			#if defined _basecomm_included
 			if(!blocked && BaseComm && BaseComm_IsClientMuted(client[a]))

--- a/addons/sourcemod/scripting/scp_sf.sp
+++ b/addons/sourcemod/scripting/scp_sf.sp
@@ -2610,7 +2610,7 @@ public void UpdateListenOverrides(float engineTime)
 					continue;
 				}
 
-				if (Forward_OnUpdateListenOverrides(client, target) != Plugin_Continue)
+				if(Forward_OnUpdateListenOverrides(client, target) != Plugin_Continue)
 				{
 					Client[target].CanTalkTo[client] = false;
 					SetListenOverride(client, target, Listen_No);

--- a/addons/sourcemod/scripting/scp_sf/forwards.sp
+++ b/addons/sourcemod/scripting/scp_sf/forwards.sp
@@ -6,6 +6,7 @@ static GlobalForward OnClass;
 static GlobalForward OnClassPre;
 static GlobalForward OnEscape;
 static GlobalForward OnReactionPre;
+static GlobalForward OnUpdateListenOverrides;
 static GlobalForward OnWeapon;
 static GlobalForward OnWeaponPre;
 
@@ -16,6 +17,7 @@ void Forward_Setup()
 	OnClassPre = new GlobalForward("SCPSF_OnClassPre", ET_Event, Param_Cell, Param_String, Param_Cell);
 	OnEscape = new GlobalForward("SCPSF_OnEscape", ET_Ignore, Param_Cell, Param_Cell);
 	OnReactionPre = new GlobalForward("SCPSF_OnReactionPre", ET_Event, Param_Cell, Param_String, Param_String);
+	OnUpdateListenOverrides = new GlobalForward("SCPSF_OnUpdateListenOverrides", ET_Ignore, Param_Cell, Param_Cell);
 	OnWeapon = new GlobalForward("SCPSF_OnWeapon", ET_Ignore, Param_Cell, Param_Cell);
 	OnWeaponPre = new GlobalForward("SCPSF_OnWeaponPre", ET_Event, Param_Cell, Param_Cell, Param_CellByRef);
 }
@@ -103,4 +105,14 @@ void Forward_OnMessage(int client, char[] name, int nameL, char[] msg, int msgL)
 		Call_Finish();
 	}
 	delete iter;
+}
+
+Action Forward_OnUpdateListenOverrides(int listener, int talker)
+{
+	Action action;
+	Call_StartForward(OnUpdateListenOverrides);
+	Call_PushCell(listener);
+	Call_PushCell(talker);
+	Call_Finish(action);
+	return action;
 }


### PR DESCRIPTION
The purpose of this is to let servers manage player-to-player voicechat before SCP does so. This does not come into effect if player a has muted player b client-side, but comes before third party server mutes.