### PR TITLE
Fix custom viewmodels not properly defaulting to their idle animation

### DIFF
--- a/addons/sourcemod/scripting/scp_sf/items.sp
+++ b/addons/sourcemod/scripting/scp_sf/items.sp
@@ -611,8 +611,8 @@ void Items_SetupViewmodel(int client, int weapon)
 			{
 				// all custom viewmodels follow this anim name convention
 				ViewModel_Create(client, Weapon.ViewmodelName, _, _, Weapon.Skin, false, true);
-				ViewModel_SetDefaultAnimation(client, "idle");
 				ViewModel_SetAnimation(client, "draw");
+				ViewModel_SetDefaultAnimation(client, "idle");
 			}
 		}
 	}

--- a/addons/sourcemod/scripting/scp_sf/items.sp
+++ b/addons/sourcemod/scripting/scp_sf/items.sp
@@ -610,9 +610,8 @@ void Items_SetupViewmodel(int client, int weapon)
 			if (Weapon.ViewmodelName[0])
 			{
 				// all custom viewmodels follow this anim name convention
-				ViewModel_Create(client, Weapon.ViewmodelName, _, _, Weapon.Skin, false, true);
+				ViewModel_Create(client, Weapon.ViewmodelName, _, _, Weapon.Skin, false, true, "idle");
 				ViewModel_SetAnimation(client, "draw");
-				ViewModel_SetDefaultAnimation(client, "idle");
 			}
 		}
 	}

--- a/addons/sourcemod/scripting/scp_sf/maps/szf.sp
+++ b/addons/sourcemod/scripting/scp_sf/maps/szf.sp
@@ -509,8 +509,7 @@ public void SZF_106Button(int client, int button)
 			if(weapon > MaxClients)
 				TF2Attrib_SetByDefIndex(weapon, 821, 0.0);
 
-			ViewModel_Create(client, ModelMelee);
-			ViewModel_SetDefaultAnimation(client, "a_fists_idle_02");
+			ViewModel_Create(client, ModelMelee, .sDefaultAnim = "a_fists_idle_02");
 			TF2_RemoveCondition(client, TFCond_SpeedBuffAlly);
 			TF2_RemoveCondition(client, TFCond_StealthedUserBuffFade);
 			TF2_RemoveCondition(client, TFCond_DodgeChance);

--- a/addons/sourcemod/scripting/scp_sf/scps/049.sp
+++ b/addons/sourcemod/scripting/scp_sf/scps/049.sp
@@ -118,8 +118,7 @@ public void SCP049_OnWeaponSwitch(int client, int entity)
 			Revive[client].GoneAt = GetGameTime()+3.0;
 		}
 
-		ViewModel_Create(client, ModelMedi);
-		ViewModel_SetDefaultAnimation(client, "b_idle");
+		ViewModel_Create(client, ModelMedi, .sDefaultAnim = "b_idle");
 		ViewModel_SetAnimation(client, "b_draw");
 	}
 }
@@ -333,8 +332,7 @@ public void SCP049_OnButton(int client, int button)
 
 			FakeClientCommandEx(client, "voicemenu 1 6");	// Activate charge
 
-			ViewModel_Create(client, ModelMelee);
-			ViewModel_SetDefaultAnimation(client, "b_idle");
+			ViewModel_Create(client, ModelMelee, .sDefaultAnim = "b_idle");
 			ViewModel_SetAnimation(client, "b_draw");
 		}
 

--- a/addons/sourcemod/scripting/scp_sf/scps/096.sp
+++ b/addons/sourcemod/scripting/scp_sf/scps/096.sp
@@ -160,8 +160,7 @@ public void SCP096_OnButton(int client, int button)
 					SetEntPropEnt(client, Prop_Send, "m_hActiveWeapon", weapon);
 				}
 
-				ViewModel_Create(client, ModelMelee);
-				ViewModel_SetDefaultAnimation(client, "a_fists_idle_02");
+				ViewModel_Create(client, ModelMelee, .sDefaultAnim = "a_fists_idle_02");
 				ViewModel_SetAnimation(client, "a_fists_idle_02");
 			}
 		}

--- a/addons/sourcemod/scripting/scp_sf/scps/106.sp
+++ b/addons/sourcemod/scripting/scp_sf/scps/106.sp
@@ -23,8 +23,7 @@ public bool SCP106_Create(int client)
 		SetEntPropEnt(client, Prop_Send, "m_hActiveWeapon", weapon);
 	}
 
-	ViewModel_Create(client, ModelMelee);
-	ViewModel_SetDefaultAnimation(client, "a_fists_idle_02");
+	ViewModel_Create(client, ModelMelee, .sDefaultAnim = "a_fists_idle_02");
 	ViewModel_SetAnimation(client, "fists_draw");
 	return false;
 }

--- a/addons/sourcemod/scripting/scp_sf/viewmodels.sp
+++ b/addons/sourcemod/scripting/scp_sf/viewmodels.sp
@@ -5,7 +5,7 @@
 
 static int ViewmodelRef[MAXPLAYERS + 1] = {INVALID_ENT_REFERENCE, ...};
 
-int ViewModel_Create(int iClient, const char[] sModel, const float vecAnglesOffset[3] = NULL_VECTOR, float flHeight = 0.0, int Skin = 0, bool ViewChange = true, bool NeedsHands = false)
+int ViewModel_Create(int iClient, const char[] sModel, const float vecAnglesOffset[3] = NULL_VECTOR, float flHeight = 0.0, int Skin = 0, bool ViewChange = true, bool NeedsHands = false, const char[] sDefaultAnim = "")
 {
 	int iViewModel = CreateEntityByName("prop_dynamic");
 	if (iViewModel <= MaxClients)
@@ -17,6 +17,9 @@ int ViewModel_Create(int iClient, const char[] sModel, const float vecAnglesOffs
 	DispatchKeyValue(iViewModel, "model", sModel);
 	DispatchKeyValue(iViewModel, "disablereceiveshadows", "0");
 	DispatchKeyValue(iViewModel, "disableshadows", "1");
+	
+	if (sDefaultAnim[0])
+		DispatchKeyValue(iViewModel, "defaultanim", sDefaultAnim);
 	
 	float vecOrigin[3], vecAngles[3];
 	GetClientAbsOrigin(iClient, vecOrigin);
@@ -86,15 +89,6 @@ void ViewModel_SetAnimation(int iClient, const char[] sAnimation)
 	{
 		SetVariantString(sAnimation);
 		AcceptEntityInput(ViewmodelRef[iClient], "SetAnimation");
-	}
-}
-
-void ViewModel_SetDefaultAnimation(int iClient, const char[] sAnimation)
-{
-	if (ViewModel_Valid(iClient))
-	{
-		SetVariantString(sAnimation);
-		AcceptEntityInput(ViewmodelRef[iClient], "SetDefaultAnimation");
 	}
 }
 


### PR DESCRIPTION
This broke on the February 18th TF2 update. Setting default animations as keyvalues on entity creation, rather than inputs right after seems to fix this.